### PR TITLE
feat: config from environment

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"github.com/kelseyhightower/envconfig"
+)
+
+type Config struct {
+	Prometheus PrometheusConfig
+}
+
+type PrometheusConfig struct {
+	Host string `envconfig:"PROM_HOST"`
+	Port uint   `envconfig:"PROM_PORT"`
+}
+
+// Singleton config instance with default values
+var globalConfig = &Config{
+	Prometheus: PrometheusConfig{
+		Host: "127.0.0.1",
+		Port: 12798,
+	},
+}
+
+func (c *Config) LoadConfig() error {
+	// Load config values from environment variables
+	// We use "dummy" as the app name here to (mostly) prevent picking up env
+	// vars that we hadn't explicitly specified in annotations above
+	err := envconfig.Process("dummy", c)
+	if err != nil {
+		return fmt.Errorf("error processing environment: %s", err)
+	}
+	return nil
+}
+// GetConfig returns the global config instance
+func GetConfig() *Config {
+	return globalConfig
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/gdamore/tcell/v2 v2.6.0
+	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/rivo/tview v0.0.0-20230406072732-e22ce9588bb4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdk
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
 github.com/gdamore/tcell/v2 v2.6.0 h1:OKbluoP9VYmJwZwq/iLb4BxwKcwGthaa1YNBJIyCySg=
 github.com/gdamore/tcell/v2 v2.6.0/go.mod h1:be9omFATkdr0D9qewWW3d+MEvl5dha+Etb5y65J2H8Y=
+github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
+github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWVwUuU=

--- a/main.go
+++ b/main.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"fmt"
+	"os"
+	"strconv"
+
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 )
@@ -9,6 +13,12 @@ var app = tview.NewApplication()
 var pages = tview.NewPages()
 
 func main() {
+	// Load our config
+	cfg := GetConfig()
+	if err := cfg.LoadConfig(); err != nil {
+		fmt.Printf("Failed to load config: %s", err)
+		os.Exit(1)
+	}
 	// capture inputs
 	app.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		// q
@@ -34,7 +44,11 @@ func main() {
 }
 
 func layout(p string) *tview.Flex {
+	// Load our config
+	cfg := GetConfig()
 	text := tview.NewTextView().SetTextColor(tcell.ColorGreen)
+	promText := tview.NewTextView().SetTextColor(tcell.ColorGreen).
+		SetText("Prometheus: http://" + cfg.Prometheus.Host + ":" + strconv.FormatUint(uint64(cfg.Prometheus.Port), 10) + "/metrics")
 	switch p {
 	case "two":
 		text.SetText("(b) to go to main page (q) to quit")
@@ -45,7 +59,7 @@ func layout(p string) *tview.Flex {
 	// Configure a flexible box, split into 3 rows
 	flex.SetDirection(tview.FlexRow).
 		// Row 1 is a box
-		AddItem(tview.NewBox().SetBorder(true),
+		AddItem(promText,
 			0,
 			2,
 			false).
@@ -53,12 +67,12 @@ func layout(p string) *tview.Flex {
 		AddItem(tview.NewFlex().SetDirection(tview.FlexRow).
 			// Row 1 is a flex set of columns
 			AddItem(tview.NewFlex().
-				// Column 1
+				// Column 1 - r2r1c1
 				AddItem(tview.NewBox().SetBorder(true),
 					0,
 					1,
 					true).
-				// Column 2
+				// Column 2 - r2r1c2
 				AddItem(tview.NewBox().SetBorder(true),
 					0,
 					4,
@@ -66,7 +80,7 @@ func layout(p string) *tview.Flex {
 				0,
 				6,
 				false).
-			// Row 2
+			// Row 2 - r2r2
 			AddItem(tview.NewBox().SetBorder(true),
 				0,
 				1,


### PR DESCRIPTION
Support configuration via environment variables.

- Import `envconfig`
- Create a Config struct with a PrometheusConfig member
- Config Prometheus host via `PROM_HOST` environment variable
- Config Prometheus port via `PROM_PORT` environment variable
- Create a `globalConfig` Config object and `GetConfig()` to fetch it
- Create a `LoadConfig()` to initialize `globalConfig`
- Update first row to display an assembled Prometheus metrics URL for a cardano-node using a `tview.TextView`