### PR TITLE
feat: json unmarshal to struct

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,6 +32,7 @@ func (c *Config) LoadConfig() error {
 	}
 	return nil
 }
+
 // GetConfig returns the global config instance
 func GetConfig() *Config {
 	return globalConfig


### PR DESCRIPTION
Convert processed Prometheus data JSON into a Go struct.

- Import `math`
- Update text view on `prom2json()` error
- Create a `Metrics` struct
- Unmarshal prom2json result bytes into `metrics`
- Create a `timeLeft(seconds)` method to convert seconds to string
- Create a stubbed `uptimes` value of 0
- Display calculated uptime string
- Display epoch number taken from `metrics.EpochNum`