### PR TITLE
feat: table

### DIFF
--- a/config.go
+++ b/config.go
@@ -6,7 +6,12 @@ import (
 )
 
 type Config struct {
+	App        AppConfig
 	Prometheus PrometheusConfig
+}
+
+type AppConfig struct {
+	NodeName string `envconfig:"NODE_NAME"`
 }
 
 type PrometheusConfig struct {
@@ -16,6 +21,9 @@ type PrometheusConfig struct {
 
 // Singleton config instance with default values
 var globalConfig = &Config{
+	App: AppConfig{
+		NodeName: "Cardano Node",
+	},
 	Prometheus: PrometheusConfig{
 		Host: "127.0.0.1",
 		Port: 12798,


### PR DESCRIPTION
Change our main Prometheus TextView into a Table.

- Add an AppConfig member to Config struct
- Configure display name via `NODE_NAME` environment variable
- Set default `Config.App.NodeName` to "Cardano Node"
- Validate that `Config.App.NodeName` is <= 19 characters
- Enable dynamic colors on `text` and update text output
- Support `esc` key to quit
- Add `headerText` to contain our header
- Add `promTable` to contain our Prometheus table
- Refactor `Metrics` collection into `getPromMetrics()`
- Refactor `getPromText()` to use `getPromMetrics()`
- Create `getPromTable()` to use `getPromMetrics()`
- Initialize `promTable` using `getPromTable()` function
- Use `promTable` instead of `promText` in our main Flex

![image](https://user-images.githubusercontent.com/380021/235324452-979ccf8d-2e2d-4ab9-b79f-218371800fc5.png)