### PR TITLE
feat: devops

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -1,0 +1,30 @@
+name: Docker CI
+
+on:
+  pull_request:
+    branches: ['main']
+    paths: ['Dockerfile','*.go','go.*','.github/workflows/ci-docker.yml']
+
+env:
+  GHCR_IMAGE_NAME: ghcr.io/blinklabs-io/snek
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: qemu
+        uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
+      - id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.GHCR_IMAGE_NAME }}
+      - name: build
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: false
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,16 @@
+# The below is pulled from upstream and slightly modified
+# https://github.com/webiny/action-conventional-commits/blob/master/README.md#usage
+
+name: Conventional Commits
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: webiny/action-conventional-commits@v1.0.3

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,33 @@
+# This file was copied from the following URL and modified:
+# https://github.com/golangci/golangci-lint-action/blob/master/README.md#how-to-use
+
+name: golangci
+on:
+  push:
+    branches: ['main']
+  pull_request:
+permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  golangci:
+    name: lint
+    strategy:
+      matrix:
+        go-version: [1.18.x, 1.19.x]
+        platform: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.50.1 # current version at time of commit
+          # Optional: golangci-lint command line arguments.
+          # args: --issues-exit-code=0
+          only-new-issues: true
+      - name: go-test
+        run: go test ./...

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,137 @@
+name: publish
+
+on:
+  push:
+    branches: ['main']
+    tags:
+      - 'v*.*.*'
+
+concurrency: ${{ github.ref }}
+
+jobs:
+  create-draft-release:
+    runs-on: ubuntu-latest
+    outputs:
+      RELEASE_ID: ${{ steps.create-release.outputs.result }}
+    steps:
+      - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
+      - uses: actions/github-script@v6
+        id: create-release
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          result-encoding: string
+          script: |
+            try {
+              const response = await github.rest.repos.createRelease({
+                draft: true,
+                generate_release_notes: true,
+                name: process.env.RELEASE_TAG,
+                owner: context.repo.owner,
+                prerelease: false,
+                repo: context.repo.repo,
+                tag_name: process.env.RELEASE_TAG,
+              });
+
+              return response.data.id;
+            } catch (error) {
+              core.setFailed(error.message);
+            }
+
+  build-binaries:
+    strategy:
+      matrix:
+        os: [linux, darwin, freebsd, windows]
+        arch: [amd64, arm64]
+    runs-on: ubuntu-latest
+    needs: [create-draft-release]
+    steps:
+      - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - name: Build binary
+        run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} make build
+      - name: Upload release asset
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          _filename=nview-${{ env.RELEASE_TAG }}-${{ matrix.os }}-${{ matrix.arch }}
+          if [[ ${{ matrix.os }} == windows ]]; then
+            _filename=${_filename}.exe
+          fi
+          mv nview ${_filename}
+          curl \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Content-Type: application/octet-stream" \
+            --data-binary @${_filename} \
+            https://uploads.github.com/repos/${{ github.repository_owner }}/nview/releases/${{ needs.create-draft-release.outputs.RELEASE_ID }}/assets?name=${_filename}
+
+  build-images:
+    runs-on: ubuntu-latest
+    needs: [create-draft-release]
+    steps:
+      - run: "echo \"RELEASE_TAG=${GITHUB_REF#refs/tags/}\" >> $GITHUB_ENV"
+      - uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: blinklabs
+          password: ${{ secrets.DOCKER_PASSWORD }} # uses token
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+      - id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            blinklabs/nview
+            ghcr.io/${{ github.repository }}
+          tags: |
+            # branch
+            type=ref,event=branch
+            # semver
+            type=semver,pattern={{version}}
+      - name: Build images
+        uses: docker/build-push-action@v3
+        with:
+          outputs: "type=registry,push=true"
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      # Update Docker Hub from README
+      - name: Docker Hub Description
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: blinklabs
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: blinklabs/nview
+          readme-filepath: ./README.md
+          short-description: "nview is a local monitoring tool for a Cardano Node"
+
+  finalize-release:
+    runs-on: ubuntu-latest
+    needs: [create-draft-release, build-binaries, build-images]
+    steps:
+      - uses: actions/github-script@v6
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            try {
+              await github.rest.repos.updateRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                release_id: ${{ needs.create-draft-release.outputs.RELEASE_ID }},
+                draft: false,
+              });
+            } catch (error) {
+              core.setFailed(error.message);
+            }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.18 AS build
+
+WORKDIR /code
+COPY . .
+RUN make build
+
+FROM cgr.dev/chainguard/glibc-dynamic AS nview
+COPY --from=build /code/nview /usr/local/bin/
+ENTRYPOINT ["/usr/local/bin/nview"]

--- a/Makefile
+++ b/Makefile
@@ -9,17 +9,22 @@ BINARIES=nview
 
 .PHONY: build mod-tidy clean test
 
+all: format build
+
 # Alias for building program binary
 build: $(BINARIES)
 
-mod-tidy:
+tidy:
 	# Needed to fetch new dependencies and add them to go.mod
 	go mod tidy
 
 clean:
 	rm -f $(BINARIES)
 
-test: mod-tidy
+format: tidy
+	go fmt ./...
+
+test: tidy
 	go test -v ./...
 
 # Build our program binaries

--- a/README.md
+++ b/README.md
@@ -1,2 +1,46 @@
 # nview
-A TUI for monitoring Cardano nodes
+
+nview is a local monitoring tool for a Cardano Node (cardano-node) meant to
+complement remote monitoring tools by providing a local view of a running
+node from the command line. It's a TUI (terminal user interface) designed to
+fit most screens.
+
+## Design and functionality
+
+The goal with nview is to provide an alternative to the Guild LiveView
+(gLiveView.sh) shell scripts which is shipped as a single binary with all of
+the functionality included natively. This allows the tool to be more portable
+to non-Linux systems by using Go standard library functionality.
+
+The design is more in line with a 12-factor application, with no config
+files or other on-disk requirements. Functionality is controlled via
+environment variables within the application's context. This prevents the
+application from being a drop-in replacement for gLiveView for Cardano Node
+administrators, but unlocks the ability to add functionality beyond that
+easily attainable with a shell script.
+
+## Usage
+
+Running nview against a running Cardano Node will work out of the box with a
+default Cardano Node configuration, which exposes metrics in Prometheus data
+format on a specific port.
+
+```
+./nview
+```
+
+Or, from source:
+```
+go run .
+```
+
+The following environment variables control the behavior of the application.
+
+- `NODE_NAME` - Changes the name displayed by nview, default is "Cardano
+  Node", maximum 19 characters
+- `PROM_HOST` - Sets the host address used to fetch Prometheus metrics from a
+  Cardano Node, default is "127.0.0.1"
+- `PROM_PORT` - Sets the host port used to fetch Prometheus metrics from a
+  Cardano Node, default is 12798
+- `PROM_TIMEOUT` - Sets the maximum number of seconds to wait for response
+  when polling a Cardano Node for Prometheus metrics, default is 3

--- a/config.go
+++ b/config.go
@@ -15,8 +15,9 @@ type AppConfig struct {
 }
 
 type PrometheusConfig struct {
-	Host string `envconfig:"PROM_HOST"`
-	Port uint   `envconfig:"PROM_PORT"`
+	Host    string `envconfig:"PROM_HOST"`
+	Port    uint   `envconfig:"PROM_PORT"`
+	Timeout uint   `envconfig:"PROM_TIMEOUT"`
 }
 
 // Singleton config instance with default values
@@ -25,8 +26,9 @@ var globalConfig = &Config{
 		NodeName: "Cardano Node",
 	},
 	Prometheus: PrometheusConfig{
-		Host: "127.0.0.1",
-		Port: 12798,
+		Host:    "127.0.0.1",
+		Port:    12798,
+		Timeout: 3,
 	},
 }
 

--- a/main.go
+++ b/main.go
@@ -206,11 +206,11 @@ func getPromText(ctx context.Context) string {
 	sb.WriteString(fmt.Sprintf(" Late (>5s) : [blue]%-22s[white]\n", strconv.FormatUint(metrics.BlocksLate, 10)))
 	// Row 2
 	blk1s := fmt.Sprintf("%.2f", metrics.BlocksW1s*100)
-	sb.WriteString(fmt.Sprintf(" Within 1s  : [blue]%s[white]%-"+strconv.Itoa(threeCol1ValueWidth - len(blk1s))+"s", blk1s, "%"))
+	sb.WriteString(fmt.Sprintf(" Within 1s  : [blue]%s[white]%-"+strconv.Itoa(threeCol1ValueWidth-len(blk1s))+"s", blk1s, "%"))
 	blk3s := fmt.Sprintf("%.2f", metrics.BlocksW3s*100)
-	sb.WriteString(fmt.Sprintf(" Within 3s  : [blue]%s[white]%-"+strconv.Itoa(threeCol2ValueWidth - len(blk3s))+"s", blk3s, "%"))
+	sb.WriteString(fmt.Sprintf(" Within 3s  : [blue]%s[white]%-"+strconv.Itoa(threeCol2ValueWidth-len(blk3s))+"s", blk3s, "%"))
 	blk5s := fmt.Sprintf("%.2f", metrics.BlocksW5s*100)
-	sb.WriteString(fmt.Sprintf(" Within 5s  : [blue]%s[white]%-"+strconv.Itoa(threeCol3ValueWidth - len(blk5s))+"s\n", blk5s, "%"))
+	sb.WriteString(fmt.Sprintf(" Within 5s  : [blue]%s[white]%-"+strconv.Itoa(threeCol3ValueWidth-len(blk5s))+"s\n", blk5s, "%"))
 
 	// NODE RESOURCE USAGE Divider
 	sb.WriteString(fmt.Sprintf("- [yellow]NODE RESOURCE USAGE[white] %s\n", strings.Repeat("- ", width-17)))
@@ -218,12 +218,12 @@ func getPromText(ctx context.Context) string {
 	// Row 1
 	sb.WriteString(fmt.Sprintf(" CPU (sys)  : [blue]%s[white]%-18s", fmt.Sprintf("%.1f", 99.0), "%"))
 	memLive := fmt.Sprintf("%.1f", float64(metrics.MemLive)/float64(1073741824))
-	sb.WriteString(fmt.Sprintf(" Mem (Live) : [blue]%s[white]%-"+strconv.Itoa(threeCol1ValueWidth - len(memLive))+"s", memLive, "G"))
+	sb.WriteString(fmt.Sprintf(" Mem (Live) : [blue]%s[white]%-"+strconv.Itoa(threeCol1ValueWidth-len(memLive))+"s", memLive, "G"))
 	sb.WriteString(fmt.Sprintf(" GC Minor   : [blue]%-"+strconv.Itoa(threeCol3ValueWidth)+"s[white]\n", strconv.FormatUint(metrics.GcMinor, 10)))
 	// Row 2
 	sb.WriteString(fmt.Sprintf(" Mem (RSS)  : [blue]%s[white]%-19s", fmt.Sprintf("%.1f", 1.2), "G"))
 	memHeap := fmt.Sprintf("%.1f", float64(metrics.MemHeap)/float64(1073741824))
-	sb.WriteString(fmt.Sprintf(" Mem (Heap) : [blue]%s[white]%-"+strconv.Itoa(threeCol1ValueWidth - len(memHeap))+"s", memHeap, "G"))
+	sb.WriteString(fmt.Sprintf(" Mem (Heap) : [blue]%s[white]%-"+strconv.Itoa(threeCol1ValueWidth-len(memHeap))+"s", memHeap, "G"))
 	sb.WriteString(fmt.Sprintf(" GC Major   : [blue]%-"+strconv.Itoa(threeCol3ValueWidth)+"s[white]\n", strconv.FormatUint(metrics.GcMajor, 10)))
 
 	return fmt.Sprint(sb.String())
@@ -285,7 +285,7 @@ func getNodeMetrics(ctx context.Context) ([]byte, int, error) {
 		return respBodyBytes, http.StatusInternalServerError, err
 	}
 	// Set a 3 second timeout
-	ctx, cancel := context.WithTimeout(ctx, time.Duration(time.Second*3))
+	ctx, cancel := context.WithTimeout(ctx, time.Second*time.Duration(cfg.Prometheus.Timeout))
 	defer cancel()
 	req.WithContext(ctx)
 	// Get metrics from the node


### PR DESCRIPTION
Create GitHub Actions workflows for testing and publishing.

- Docker CI workflow to build container images for `linux/amd64` and `linux/arm64`
- Conventional Commits workflow to enforce [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
- golangci workflow to run `golangci-lint` and `go test` on a matrix of Golang versions and platforms
  - Go: 1.18, 1.19
  - Platform: Ubuntu, MacOS
- Publish workflow to create GitHub releases, container images, and binaries
  - Images created and published on merge to `main` or a matching (`v*.*.*`) git tag
    - Docker Hub: `blinklabs/nview` for `linux/amd64` and `linux/arm64`
    - GitHub Container Registry: `ghcr.io/blinklabs-io/nview` for `linux/amd64` and `linux/arm64`
  - Binaries built for a matrix of platforms and architectures
    - Platform: Linux, MacOS, FreeBSD, Windows
    - Architecture: AMD64, ARM64 (v8)
  - Creates a GitHub release and publishes binaries to it on git tag
- Modified the `Makefile` to include a `format` target
- Renamed `Makefile` target `mod-tidy` to `tidy`
- Improved README and close #12 
- Add a Dockerfile to build using [Chainguard](https://www.chainguard.dev/) images