### PR TITLE
feat: info page

### DIFF
--- a/config.go
+++ b/config.go
@@ -13,6 +13,7 @@ type Config struct {
 
 type AppConfig struct {
 	NodeName string `envconfig:"NODE_NAME"`
+	Network  string `envconfig:"NETWORK"`
 }
 
 type NodeConfig struct {
@@ -30,6 +31,7 @@ type PrometheusConfig struct {
 var globalConfig = &Config{
 	App: AppConfig{
 		NodeName: "Cardano Node",
+		Network:  "Mainnet",
 	},
 	Node: NodeConfig{
 		Binary: "cardano-node",


### PR DESCRIPTION
Create an info page.

- Support setting display network name via `NETWORK` environment variable
- Move footer text from global `footerText`
- Track the currently active page using `active` global variable
- Stub Role and Version in `headerText`
- Support `h` key for navigating to main page
- Support `i` key for navigating to info page
- Clear and set `footerText` on key press
- Conditionally clear and set `text` in our refresh loop
- Move `uptimes` to a global
- Only update `uptimes` if we get a `createTime` from the `cardano-node` process
- Create `getInfoText()` to return the info page text

![image](https://user-images.githubusercontent.com/380021/236544736-81c0975c-547a-405e-92db-e1df9cf36a38.png)