### PR TITLE
feat: dns and peers in

### DIFF
--- a/main.go
+++ b/main.go
@@ -271,6 +271,7 @@ func getTestText(ctx context.Context) string {
 
 	// Display progress
 	sb.WriteString(fmt.Sprintf(" Incoming peers: %v", peersFiltered))
+	sb.WriteString(fmt.Sprintf(" Outgoing peers: %v", peersOut))
 
 	failCount = 0
 	return fmt.Sprint(sb.String())


### PR DESCRIPTION
Fetch external IP address using DNS resolution and begin peer processing.

- Import `net`
- Move `role` to a global variable for later use
- Create a local `net.Resolver` using `resolver1.opendns.com:53`
- Lookup IPv4 address for `myip.opendns.com` to get external IP address
- Process `peersIn` and add non-local peers to `peersFiltered` []string
- Process connections for non-P2P nodes