### PR TITLE
feat: epoch progress bar

### DIFF
--- a/config.go
+++ b/config.go
@@ -66,10 +66,11 @@ var globalConfig = &Config{
 		Retries:  3,
 	},
 	Node: NodeConfig{
-		Binary:     "cardano-node",
-		Network:    "mainnet",
-		Port:       3001,
-		SocketPath: "/opt/cardano/ipc/socket",
+		Binary:            "cardano-node",
+		Network:           "mainnet",
+		Port:              3001,
+		ShelleyTransEpoch: -1,
+		SocketPath:        "/opt/cardano/ipc/socket",
 	},
 	Prometheus: PrometheusConfig{
 		Host:    "127.0.0.1",

--- a/env.go
+++ b/env.go
@@ -110,6 +110,10 @@ func timeLeft(t uint64) string {
 func timeUntilNextEpoch() uint64 {
 	cfg := GetConfig()
 	currentTimeSec := uint64(time.Now().Unix() - 1)
-	result := ((uint64(cfg.Node.ShelleyTransEpoch) * cfg.Node.ByronGenesis.EpochLength * cfg.Node.ByronGenesis.SlotLength) / 1000) + ((getEpoch() + uint64(1) - uint64(cfg.Node.ShelleyTransEpoch)) * cfg.Node.ByronGenesis.EpochLength * cfg.Node.ByronGenesis.SlotLength) - currentTimeSec + cfg.Node.ByronGenesis.StartTime
+	ste := uint64(cfg.Node.ShelleyTransEpoch)
+	bgel := cfg.Node.ByronGenesis.EpochLength
+	bgsl := cfg.Node.ByronGenesis.SlotLength
+	byronLength := (ste * bgel * bgsl) / 1000
+	result := byronLength + ((getEpoch() + 1 - ste) * bgel * bgsl) - currentTimeSec + cfg.Node.ByronGenesis.StartTime
 	return uint64(result)
 }


### PR DESCRIPTION
Display a epoch progress bar and fix tip ref and diff.

- Set Config.Node.ShelleyTransEpoch to `-1` by default
- Split up `timeUntilNextEpoch()` calculations, which is still failing to give correct results
- Add epoch progress bar to main and test pages
- Add a Byron era length debug display to test page
- Support Byron era epochs in epoch progress displays
- Fix a typo in the Core section on main

![image](https://github.com/blinklabs-io/nview/assets/380021/ee5c825d-2221-4a60-b255-55dfe064e340)