### PR TITLE
feat: peers page

### DIFF
--- a/env.go
+++ b/env.go
@@ -62,6 +62,11 @@ func getNodeMetrics(ctx context.Context) ([]byte, int, error) {
 	return respBodyBytes, resp.StatusCode, nil
 }
 
+// Calculate current KES period from tip ref
+func getCurrentKESPeriod(g *localstatequery.GenesisConfigResult) uint64 {
+	return getSlotTipRef(g) / uint64(g.SlotsPerKESPeriod)
+}
+
 // Calculate epoch from current second
 func getEpoch() uint64 {
 	cfg := GetConfig()

--- a/env.go
+++ b/env.go
@@ -63,6 +63,7 @@ func getNodeMetrics(ctx context.Context) ([]byte, int, error) {
 }
 
 // Calculate current KES period from tip ref
+//nolint:unused
 func getCurrentKESPeriod(g *localstatequery.GenesisConfigResult) uint64 {
 	return getSlotTipRef(g) / uint64(g.SlotsPerKESPeriod)
 }

--- a/main.go
+++ b/main.go
@@ -824,6 +824,7 @@ func getInfoText(ctx context.Context) string {
 	return fmt.Sprint(sb.String())
 }
 
+//nolint:unused
 var checkPeers bool = false
 
 func getPeerText(ctx context.Context) string {


### PR DESCRIPTION
Move peer analysis code from test page to its own page.

- Create `getCurrentKESPeriod()` to calculate from tip ref
- Rename `getPromText()` to `getHomeText()` to reflect correct use
- Remove center alignment on header text
- Calculate header padding from input lengths
- Support `p` to display peer analysis
- Replace `r` with `p` in default footer text
- Increase dynamic size of main section Flex item
- Set static size on footer section Flex item
- Drop epoch progress bar from test page, since it's on home
- Switch to displaying return of `timeUntilNextEpoch()` on test page
- Create `getPeerText()` to generate peers page
- Move peer analysis code from test page to peers page
- Add "Core" section to test page to start work on display

![image](https://github.com/blinklabs-io/nview/assets/380021/1797ea80-6bf1-4359-8df4-9d478c7f53c7)