### PR TITLE
feat: stub collect stats from peers

### DIFF
--- a/env.go
+++ b/env.go
@@ -63,6 +63,7 @@ func getNodeMetrics(ctx context.Context) ([]byte, int, error) {
 }
 
 // Calculate current KES period from tip ref
+//
 //nolint:unused
 func getCurrentKESPeriod(g *localstatequery.GenesisConfigResult) uint64 {
 	return getSlotTipRef(g) / uint64(g.SlotsPerKESPeriod)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/blinklabs-io/tview
 go 1.18
 
 require (
-	github.com/blinklabs-io/gouroboros v0.38.4
+	github.com/blinklabs-io/gouroboros v0.40.1
 	github.com/gdamore/tcell/v2 v2.6.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/prometheus/client_model v0.4.0
@@ -32,7 +32,7 @@ require (
 	github.com/tklauser/numcpus v0.6.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
-	golang.org/x/crypto v0.8.0 // indirect
+	golang.org/x/crypto v0.9.0 // indirect
 	golang.org/x/sys v0.8.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/blinklabs-io/gouroboros v0.38.4 h1:jRWbyPZ9+s4itUmMta33KHafaPB5MLjhY6M51GFq0K4=
-github.com/blinklabs-io/gouroboros v0.38.4/go.mod h1:InYtIxaiyXAEZ+fB5Gumy9O6MYY2glfrtCnvihVH3uI=
+github.com/blinklabs-io/gouroboros v0.40.1 h1:+aioKYE7o+Ekgo9VLD4IIRXeryP9pUR3IhasDR6+jcM=
+github.com/blinklabs-io/gouroboros v0.40.1/go.mod h1:YNHQqwU1yv620T5C+umkDmYf8BgBHlm6QpI9LUQ3Jhw=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -76,8 +76,8 @@ github.com/yusufpapurcu/wmi v1.2.2 h1:KBNDSne4vP5mbSWnJbO+51IMOXJB67QiYCSBrubbPR
 github.com/yusufpapurcu/wmi v1.2.2/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.8.0 h1:pd9TJtTueMTVQXzk8E2XESSMQDj/U7OUu0PqJqPXQjQ=
-golang.org/x/crypto v0.8.0/go.mod h1:mRqEX+O9/h5TFCrQhkgjo2yKi0yYA+9ecGkdQoHrywE=
+golang.org/x/crypto v0.9.0 h1:LF6fAI+IutBocDJ2OT0Q1g8plpYljMZ4+lty+dsqw3g=
+golang.org/x/crypto v0.9.0/go.mod h1:yrmDGqONDYtNj3tH8X9dzUun2m2lzPa9ngI6/RUPGR0=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=

--- a/node.go
+++ b/node.go
@@ -62,7 +62,7 @@ func getGenesisConfig(cfg *Config) *localstatequery.GenesisConfigResult {
 			os.Exit(1)
 		}
 	}()
-	o, err := ouroboros.New(
+	o, err := ouroboros.NewConnection(
 		ouroboros.WithConnection(conn),
 		ouroboros.WithNetworkMagic(uint32(cfg.Node.NetworkMagic)),
 		ouroboros.WithErrorChan(errorChan),
@@ -98,7 +98,7 @@ func getProtocolParams(cfg *Config) *localstatequery.CurrentProtocolParamsResult
 			os.Exit(1)
 		}
 	}()
-	o, err := ouroboros.New(
+	o, err := ouroboros.NewConnection(
 		ouroboros.WithConnection(conn),
 		ouroboros.WithNetworkMagic(uint32(cfg.Node.NetworkMagic)),
 		ouroboros.WithErrorChan(errorChan),

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,54 @@
+// Copyright 2023 Blink Labs, LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"strings"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+)
+
+// Converts a prometheus http response byte array into a JSON byte array
+func prom2json(prom []byte) ([]byte, error) {
+	// {"name": 0}
+	out := make(map[string]interface{})
+	b := []byte{}
+	parser := &expfmt.TextParser{}
+	families, err := parser.TextToMetricFamilies(strings.NewReader(string(prom)))
+	if err != nil {
+		return b, err
+	}
+	for _, val := range families {
+		for _, m := range val.GetMetric() {
+			switch val.GetType() {
+			case dto.MetricType_COUNTER:
+				out[val.GetName()] = m.GetCounter().GetValue()
+			case dto.MetricType_GAUGE:
+				out[val.GetName()] = m.GetGauge().GetValue()
+			case dto.MetricType_UNTYPED:
+				out[val.GetName()] = m.GetUntyped().GetValue()
+			default:
+				return b, err
+			}
+		}
+	}
+	b, err = json.MarshalIndent(out, "", "    ")
+	if err != nil {
+		return b, err
+	}
+	return b, nil
+}


### PR DESCRIPTION
Loop through each peer and collect stubbed round trip time statistics.

- Update to gOuroboros 0.40.1
- Move `prom2json` to `utils.go` file
- Create `peerAnalysisDate` to track last analysis run date in seconds
- Filter all unused items from golangci-lint checks in `getPeerText()` (for now)
- Remove the uptime section from `getPeerText()`
- Only display public IP when not checking peers
- Create `PeerStats` struct to hold peer statistics
- Loop over `peersFiltered` and populate `peerStats` instance of `PeerStats` with stubbed RTT data
- Display raw peer stats on the peers page