### PR TITLE
feat: rtt graph on peers page

### DIFF
--- a/main.go
+++ b/main.go
@@ -854,7 +854,7 @@ func getPeerText(ctx context.Context) string {
 	// Refresh metrics from host
 	processMetrics, err := getProcessMetrics(ctx)
 	if err != nil {
-		return fmt.Sprintf(" [red]Could not get process metrics![white]\n")
+		return fmt.Sprintf(" [red]Could not get process metrics![white]%s\n", "")
 	}
 
 	var sb strings.Builder


### PR DESCRIPTION
Create a RTT graph on peers page.

- Add `showPeers` variable to track showing peer stats
- Set `showPeers` to false on return to main
- Set `checkPeers` to true on `p` keypress
- Set `showPeers` to false on `p` keypress
- Add an active "peer" check in main loop to set text on peers page
- Replace `[magenta]` color code with `[fuchsia]` everywhere
- Check for `showPeers` on info page and display appropriate text
- Update stub peerRTT math to give better fake latency spread
- Store "PCT" variables as float32
- Display a RTT peers / percent / graph on peers page

![image](https://github.com/blinklabs-io/nview/assets/380021/9caad401-33b9-40f0-9a50-a705fe864a0b)