### PR TITLE
feat: display core metrics

### DIFF
--- a/config.go
+++ b/config.go
@@ -36,13 +36,14 @@ type AppConfig struct {
 }
 
 type NodeConfig struct {
-	Binary            string             // TODO: make this configurable
 	ByronGenesis      ByronGenesisConfig `yaml:"byron"`
+	Binary            string             // TODO: make this configurable
 	Network           string             `yaml:"network"          envconfig:"CARDANO_NETWORK"`
+	SocketPath        string             `yaml:"socketPath"       envconfig:"CARDANO_NODE_SOCKET_PATH"`
 	NetworkMagic      uint32             `yaml:"networkMagic"     envconfig:"CARDANO_NODE_NETWORK_MAGIC"`
 	Port              uint32             `yaml:"port"             envconfig:"CARDANO_PORT"`
 	ShelleyTransEpoch int32              `yaml:"shellyTransEpoch" envconfig:"SHELLEY_TRANS_EPOCH"`
-	SocketPath        string             `yaml:"socketPath"       envconfig:"CARDANO_NODE_SOCKET_PATH"`
+	BlockProducer     bool               `yaml:"blockProducer"    envconfig:"CARDANO_BLOCK_PRODUCER"`
 }
 
 type PrometheusConfig struct {

--- a/env.go
+++ b/env.go
@@ -92,6 +92,13 @@ func getSlotTipRef(g *localstatequery.GenesisConfigResult) uint64 {
 	return byronSlots + ((currentTimeSec - byronEndTime) / uint64(g.SlotLength/1000000))
 }
 
+// Calculate KES expiration from node metrics
+func kesExpiration(g *localstatequery.GenesisConfigResult, p *PromMetrics) time.Time {
+	currentTimeSec := uint64(time.Now().Unix() - 1)
+	expirationTimeSec := currentTimeSec - (uint64(g.SlotLength/1000000) * (getSlotTipRef(g) % uint64(g.SlotsPerKESPeriod))) + (uint64(g.SlotLength/1000000) + uint64(g.SlotsPerKESPeriod)*p.RemainingKesPeriods)
+	return time.Unix(int64(expirationTimeSec), 0)
+}
+
 // Calculate expected interval between blocks
 func slotInterval(g *localstatequery.GenesisConfigResult) uint64 {
 	// g.SlotLength is nanoseconds

--- a/node.go
+++ b/node.go
@@ -28,7 +28,6 @@ func buildLocalStateQueryConfig() localstatequery.Config {
 	return localstatequery.NewConfig()
 }
 
-//nolint:unused
 func buildChainSyncConfig() chainsync.Config {
 	return chainsync.NewConfig()
 }
@@ -91,6 +90,8 @@ func getGenesisConfig(cfg *Config) *localstatequery.GenesisConfigResult {
 }
 
 // Get Protocol Parameters from a running node using Ouroboros NtC
+//
+//nolint:unused
 func getProtocolParams(cfg *Config) *localstatequery.CurrentProtocolParamsResult {
 	var result *localstatequery.CurrentProtocolParamsResult
 	// Get a connection and setup our error channels

--- a/node.go
+++ b/node.go
@@ -28,6 +28,7 @@ func buildLocalStateQueryConfig() localstatequery.Config {
 	return localstatequery.NewConfig()
 }
 
+//nolint:unused
 func buildChainSyncConfig() chainsync.Config {
 	return chainsync.NewConfig()
 }

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,44 @@
+// Copyright 2023 Blink Labs, LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"net"
+	"time"
+)
+
+func getPublicIP(ctx context.Context) (net.IP, error) {
+	// First, check for external address using custom resolver so we can
+	// use a given DNS server to resolve our public address
+	r := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			d := net.Dialer{
+				Timeout: time.Second * time.Duration(3),
+			}
+			return d.DialContext(ctx, network, "resolver1.opendns.com:53")
+		},
+	}
+	// Lookup special address to get our public IP
+	ips, err := r.LookupIP(ctx, "ip4", "myip.opendns.com")
+	if err != nil {
+		return nil, err
+	}
+	if ips != nil {
+		return ips[0], nil
+	}
+	return nil, nil
+}


### PR DESCRIPTION
Display core metrics for a block producer on home page.

- Import `runtime`
- Support `CARDANO_BLOCK_PRODUCER` variable to set role
- Create `kesExpiration()` to calculate the KES expiration as time.Time
- Remove usage of `getProtocolParams()` on test page
- Remove "Core" display on test page
- Add "Prometheus metrics" display on test page
- Use correct formatting values on "Mem (Live)" and "Mem (Heap)"
- Display KES information in "Core" display on home page
- Display "Block Production" metrics sourced from Prometheus
- Skip peer analysis on FreeBSD... thanks @reqlez for reporting!
- Refactor public IP address code into `getPublicIP()` in `utils.go`