### PR TITLE
chore(refactor): move config to an internal package

### DIFF
--- a/env.go
+++ b/env.go
@@ -23,12 +23,14 @@ import (
 	"time"
 
 	"github.com/blinklabs-io/gouroboros/protocol/localstatequery"
+
+	"github.com/blinklabs-io/nview/internal/config"
 )
 
 // Fetches the node metrics and return a byte array
 func getNodeMetrics(ctx context.Context) ([]byte, int, error) {
 	// Load our config and get host/port
-	cfg := GetConfig()
+	cfg := config.GetConfig()
 	url := fmt.Sprintf(
 		"http://%s:%d/metrics",
 		cfg.Prometheus.Host,
@@ -71,7 +73,7 @@ func getCurrentKESPeriod(g *localstatequery.GenesisConfigResult) uint64 {
 
 // Calculate epoch from current second
 func getEpoch() uint64 {
-	cfg := GetConfig()
+	cfg := config.GetConfig()
 	currentTimeSec := uint64(time.Now().Unix() - 1)
 	byronEndTime := cfg.Node.ByronGenesis.StartTime + ((uint64(cfg.Node.ShelleyTransEpoch) * cfg.Node.ByronGenesis.EpochLength * cfg.Node.ByronGenesis.SlotLength) / 1000)
 	result := uint64(
@@ -82,7 +84,7 @@ func getEpoch() uint64 {
 
 // Calculate slot number
 func getSlotTipRef(g *localstatequery.GenesisConfigResult) uint64 {
-	cfg := GetConfig()
+	cfg := config.GetConfig()
 	currentTimeSec := uint64(time.Now().Unix() - 1)
 	byronSlots := uint64(cfg.Node.ShelleyTransEpoch) * cfg.Node.ByronGenesis.EpochLength
 	byronEndTime := cfg.Node.ByronGenesis.StartTime + ((uint64(cfg.Node.ShelleyTransEpoch) * cfg.Node.ByronGenesis.EpochLength * cfg.Node.ByronGenesis.SlotLength) / 1000)
@@ -122,7 +124,7 @@ func timeLeft(t uint64) string {
 }
 
 func timeUntilNextEpoch() uint64 {
-	cfg := GetConfig()
+	cfg := config.GetConfig()
 	currentTimeSec := uint64(time.Now().Unix() - 1)
 	ste := uint64(cfg.Node.ShelleyTransEpoch)
 	bgel := cfg.Node.ByronGenesis.EpochLength

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package config
 
 import (
 	"fmt"

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/shirou/gopsutil/v3/process"
 	terminal "golang.org/x/term"
 
+	"github.com/blinklabs-io/nview/internal/config"
 	"github.com/blinklabs-io/nview/internal/version"
 )
 
@@ -80,7 +81,7 @@ func main() {
 	flag.Parse()
 
 	// Load config
-	cfg, err := LoadConfig(cmdlineFlags.configFile)
+	cfg, err := config.LoadConfig(cmdlineFlags.configFile)
 	if err != nil {
 		fmt.Printf("Failed to load config: %s", err)
 		os.Exit(1)
@@ -284,7 +285,7 @@ var uptimes uint64
 var epochItemsLast = 0
 
 func getTestText(ctx context.Context, promMetrics *PromMetrics) string {
-	cfg := GetConfig()
+	cfg := config.GetConfig()
 	// Refresh process metrics from host
 	processMetrics, err := getProcessMetrics(ctx)
 	if err != nil {
@@ -399,7 +400,7 @@ func getTestText(ctx context.Context, promMetrics *PromMetrics) string {
 }
 
 func getHomeText(ctx context.Context, promMetrics *PromMetrics) string {
-	cfg := GetConfig()
+	cfg := config.GetConfig()
 	processMetrics, err := getProcessMetrics(ctx)
 	if err != nil {
 		uptimes = 0
@@ -916,9 +917,8 @@ var checkPeers bool = false
 var pingPeers bool = false
 var showPeers bool = false
 
-//nolint:unused
 func getPeerText(ctx context.Context) string {
-	cfg := GetConfig()
+	cfg := config.GetConfig()
 	// Refresh metrics from host
 	processMetrics, err := getProcessMetrics(ctx)
 	if err != nil {
@@ -1334,7 +1334,7 @@ type Peer struct {
 }
 
 func getProcessMetrics(ctx context.Context) (*process.Process, error) {
-	cfg := GetConfig()
+	cfg := config.GetConfig()
 	r, _ := process.NewProcessWithContext(ctx, 0)
 	processes, err := process.ProcessesWithContext(ctx)
 	if err != nil {

--- a/node.go
+++ b/node.go
@@ -22,6 +22,8 @@ import (
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/protocol/chainsync"
 	"github.com/blinklabs-io/gouroboros/protocol/localstatequery"
+
+	"github.com/blinklabs-io/nview/internal/config"
 )
 
 func buildLocalStateQueryConfig() localstatequery.Config {
@@ -33,7 +35,7 @@ func buildChainSyncConfig() chainsync.Config {
 	return chainsync.NewConfig()
 }
 
-func createClientConnection(cfg *Config) net.Conn {
+func createClientConnection(cfg *config.Config) net.Conn {
 	var err error
 	var conn net.Conn
 	var dialProto string
@@ -54,7 +56,7 @@ func createClientConnection(cfg *Config) net.Conn {
 }
 
 // Get Genesis Config from a running node using Ouroboros NtC
-func getGenesisConfig(cfg *Config) *localstatequery.GenesisConfigResult {
+func getGenesisConfig(cfg *config.Config) *localstatequery.GenesisConfigResult {
 	var result *localstatequery.GenesisConfigResult
 	// Get a connection and setup our error channels
 	conn := createClientConnection(cfg)
@@ -93,7 +95,7 @@ func getGenesisConfig(cfg *Config) *localstatequery.GenesisConfigResult {
 // Get Protocol Parameters from a running node using Ouroboros NtC
 //
 //nolint:unused
-func getProtocolParams(cfg *Config) *localstatequery.CurrentProtocolParamsResult {
+func getProtocolParams(cfg *config.Config) *localstatequery.CurrentProtocolParamsResult {
 	var result *localstatequery.CurrentProtocolParamsResult
 	// Get a connection and setup our error channels
 	conn := createClientConnection(cfg)
@@ -132,7 +134,7 @@ func getProtocolParams(cfg *Config) *localstatequery.CurrentProtocolParamsResult
 // Get remote tip
 //
 //nolint:unused
-func getRemoteTip(cfg *Config, address string) *chainsync.Tip {
+func getRemoteTip(cfg *config.Config, address string) *chainsync.Tip {
 	var result *chainsync.Tip
 	// Get a connection and setup our error channels
 	conn := createRemoteClientConnection(address)

--- a/utils.go
+++ b/utils.go
@@ -20,10 +20,12 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/blinklabs-io/nview/internal/config"
 )
 
 func getNodeVersion() (version string, revision string, err error) {
-	cfg := GetConfig()
+	cfg := config.GetConfig()
 	cmd := exec.Command(cfg.Node.Binary, "version")
 	stdout, err := cmd.Output()
 	if err != nil {


### PR DESCRIPTION
Minor refactoring of the code to move the config.go code into a `config` package, which we put under `internal` to indicate that it's not intended to be used outside this code.

- Move `config.go` to `internal/config` and change package name to `config`
- Import `config` package
- Use `config.LoadConfig()` to load the initial configuration
- Use `config.GetConfig()` to get configuration information