### PR TITLE
fix: crash around setting current epoch

### DIFF
--- a/main.go
+++ b/main.go
@@ -103,11 +103,10 @@ func main() {
 		)
 	}
 	// Set current epoch from Prometheus metrics
-	currentEpoch = uint32(metrics.EpochNum)
-	// TODO: temp hack to use currentEpoch
-	if currentEpoch > 0 {
-		// Do something non-useful
-		text.SetText(fmt.Sprintf("%d", currentEpoch))
+	if metrics != nil {
+		currentEpoch = uint32(metrics.EpochNum)
+	} else {
+		currentEpoch = 0
 	}
 
 	// Populate initial text from metrics
@@ -417,7 +416,7 @@ func getHomeText(ctx context.Context, promMetrics *PromMetrics) string {
 		if role != "Core" {
 			role = "Core"
 		}
-	} else if promMetrics.AboutToLead > 0 {
+	} else if promMetrics != nil && promMetrics.AboutToLead > 0 {
 		if role != "Core" {
 			role = "Core"
 		}
@@ -486,7 +485,9 @@ func getHomeText(ctx context.Context, promMetrics *PromMetrics) string {
 	// Epoch progress
 	var epochProgress float32
 	genesisConfig := getGenesisConfig(cfg)
-	if promMetrics.EpochNum >= uint64(cfg.Node.ShelleyTransEpoch) {
+	if promMetrics == nil {
+		epochProgress = float32(0.0)
+	} else if promMetrics.EpochNum >= uint64(cfg.Node.ShelleyTransEpoch) {
 		epochProgress = float32(
 			(float32(promMetrics.SlotInEpoch) / float32(genesisConfig.EpochLength)) * 100,
 		)
@@ -499,10 +500,13 @@ func getHomeText(ctx context.Context, promMetrics *PromMetrics) string {
 	// epochTimeLeft := timeLeft(timeUntilNextEpoch())
 
 	// Epoch
+	if promMetrics != nil {
+		currentEpoch = uint32(promMetrics.EpochNum)
+	}
 	sb.WriteString(
 		fmt.Sprintf(
 			" Epoch [blue]%d[white] [[blue]%s%%[white]], [blue]%s[white] %-12s\n",
-			promMetrics.EpochNum,
+			currentEpoch,
 			epochProgress1dec,
 			"N/A",
 			"remaining",


### PR DESCRIPTION
In some cases, our metrics may not be fetched correctly by the time we initialize. Guard around this by checking if our metrics are `nil` before trying to use them.

Closes #76 