### PR TITLE
fix: scroll to beginning of text

### DIFF
--- a/main.go
+++ b/main.go
@@ -191,6 +191,7 @@ func main() {
 			checkPeers = true
 			pingPeers = false
 			showPeers = false
+			scrollPeers = false
 			text.Clear()
 			footerText.Clear()
 			footerText.SetText(" [yellow](esc/q) Quit[white] | [yellow](h) Return home")
@@ -254,6 +255,11 @@ func main() {
 				} else {
 					text.Clear()
 					text.SetText(getPeerText(ctx))
+					// Scroll to the top only once
+					if scrollPeers {
+						scrollPeers = false
+						text.ScrollToBeginning()
+					}
 				}
 			}
 			if active == "test" {
@@ -915,6 +921,7 @@ var peerAnalysisDate uint64
 var checkPeers bool = false
 var pingPeers bool = false
 var showPeers bool = false
+var scrollPeers bool = false
 
 //nolint:unused
 func getPeerText(ctx context.Context) string {
@@ -1057,11 +1064,13 @@ func getPeerText(ctx context.Context) string {
 
 		checkPeers = false
 		pingPeers = true
+		scrollPeers = false
 		// sb.WriteString(fmt.Sprintf("checkPeers=%v, pingPeers=%v, showPeers=%v\n", checkPeers, pingPeers, showPeers))
 		failCount = 0
 		return sb.String()
 	} else if pingPeers {
 		pingPeers = false
+		scrollPeers = false
 		peerCount := len(peersFiltered)
 		printStart := width - (peerCount * 2) - 2
 		sb.WriteString(fmt.Sprintf("%"+strconv.Itoa(printStart-1)+"s [blue]%"+strconv.Itoa(peerCount)+"s[white]/[green]%d[white]\n",
@@ -1135,10 +1144,12 @@ func getPeerText(ctx context.Context) string {
 		peerAnalysisDate = uint64(time.Now().Unix() - 1)
 		checkPeers = false
 		showPeers = true
+		scrollPeers = true
 		// sb.WriteString(fmt.Sprintf("checkPeers=%v, pingPeers=%v, showPeers=%v\n", checkPeers, pingPeers, showPeers))
 		failCount = 0
 		return sb.String()
 	} else if showPeers {
+		scrollPeers = false
 		peerCount := len(peersFiltered)
 		sb.WriteString("       RTT : Peers / Percent\n")
 		sb.WriteString(fmt.Sprintf(


### PR DESCRIPTION
Resolves an issue where the Peer Analysis page is scrolled to the bottom, hiding the latency graphs at the top, which is the most likely piece of at a glance information most would want.

- Create `scrollPeers` boolean to track our state
- Set `scrollPeers` to true at the end of peer ping
- Set `ScrollToBeginning()` when `scrollPeers` is true during refresh loop, toggle false
- Set `scrollPeers` to false at beginning of showPeers conditional within `getPeerText()`

Fixes #58 