### PR TITLE
fix: explicit handling for all prometheus metric types

### DIFF
--- a/prometheus.go
+++ b/prometheus.go
@@ -122,8 +122,12 @@ func prom2json(prom []byte) ([]byte, error) {
 				out[val.GetName()] = m.GetGauge().GetValue()
 			case dto.MetricType_UNTYPED:
 				out[val.GetName()] = m.GetUntyped().GetValue()
+			case dto.MetricType_SUMMARY,
+				dto.MetricType_HISTOGRAM,
+				dto.MetricType_GAUGE_HISTOGRAM:
+				return b, nil
 			default:
-				return b, err
+				return b, nil
 			}
 		}
 	}


### PR DESCRIPTION
Add some handling for the metrics types we don't use, so we can see which are directly supported.