### PR TITLE
Read from a PID file when targeting Amaru

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 # vendor/
 
 nview
+
+config.yaml

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -21,8 +21,8 @@ node:
   # Name of the node you are running.
   #
   # Valid values are:
-  #   - `cardano-node`
-  #   -  `amaru`
+  # - `cardano-node`
+  # -  `amaru`
   #
   # This can also be set via the CARDANO_NODE_BINARY environment variable
   binary: cardano-node
@@ -61,7 +61,7 @@ node:
 
   # The path to the PID File of your running node
   #
-  # This is only used when the `binary` value is `cardano-node`.
+  # This is only used when the `binary` value is `amaru`.
   # Otherwise it is ignored.
   pidFile:
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -8,7 +8,7 @@ app:
   # This can also be set via the NODE_NAME environment variable
   nodeName: Cardano Node
 
-  # Named Cardano network for cardano-node
+  # Named Cardano network for the node
   #
   # This is a short-cut to select the NetworkMagic and can be used to
   # select mainnet, preprod, preview, or sancho networks.
@@ -18,7 +18,16 @@ app:
   network:
 
 node:
-  # Named Cardano network for cardano-node
+  # Name of the node you are running.
+  #
+  # Valid values are:
+  #   - `cardano-node`
+  #   -  `amaru`
+  #
+  # This can also be set via the CARDANO_NODE_BINARY environment variable
+  binary: cardano-node
+
+  # Named Cardano network for the node
   #
   # This is a short-cut to select the NetworkMagic and can be used to
   # select mainnet, preprod, preview, or sancho networks.
@@ -26,7 +35,7 @@ node:
   # This can also be set via the CARDANO_NETWORK environment variable
   network: mainnet
 
-  # NetworkMagic for network for cardano-node
+  # NetworkMagic for network for the node
   #
   # This selects the correct network for operation and can be configured to
   # any network, not just the named networks.
@@ -35,29 +44,36 @@ node:
   # variable
   networkMagic:
 
-  # Port for cardano-node
+  # Port for the node
   #
-  # Listening port for cardano-node for NtN communication.
+  # Listening port for the node for NtN communication.
   #
   # This can also be set via the CARDANO_PORT environment variable
   port: 3001
 
-  # Socket path for cardano-node
+  # Socket path for the node
   #
-  # Listening UNIX socket path and file name for cardano-node NtC
+  # Listening UNIX socket path and file name for the node NtC
   # communication.
   #
   # This can also be set via the CARDANO_NODE_SOCKET_PATH environment variable
   socketPath:
 
+  # The path to the PID File of your running node
+  #
+  # This is only used when the `binary` value is `cardano-node`.
+  # Otherwise it is ignored.
+  pidFile:
+
+
 prometheus:
-  # host/port for cardano-node Prometheus metrics
+  # host/port for the node Prometheus metrics
   #
   # These can also be set via the PROM_HOST and PROM_PORT environment variables
   host: 127.0.0.1
   port: 12798
 
-  # Timeout for connections to cardano-node
+  # Timeout for connections to the node
   #
   # This can also be set via the PROM_TIMEOUT environment variable
   timeout: 3

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,7 +40,7 @@ type AppConfig struct {
 type NodeConfig struct {
 	ByronGenesis      ByronGenesisConfig   `yaml:"byron"`
 	Binary            string               `yaml:"binary"           envconfig:"CARDANO_NODE_BINARY"`
-	PidFile           string               `yaml:"pidFile"`
+	PidFile           string               `yaml:"pidFile"          envconfig:"CARDANO_NODE_PID_FILE"`
 	Network           string               `yaml:"network"          envconfig:"CARDANO_NETWORK"`
 	SocketPath        string               `yaml:"socketPath"       envconfig:"CARDANO_NODE_SOCKET_PATH"`
 	NetworkMagic      uint32               `yaml:"networkMagic"     envconfig:"CARDANO_NODE_NETWORK_MAGIC"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,7 @@ type AppConfig struct {
 type NodeConfig struct {
 	ByronGenesis      ByronGenesisConfig   `yaml:"byron"`
 	Binary            string               `yaml:"binary"           envconfig:"CARDANO_NODE_BINARY"`
+	PidFile           string               `yaml:"pidFile"`
 	Network           string               `yaml:"network"          envconfig:"CARDANO_NETWORK"`
 	SocketPath        string               `yaml:"socketPath"       envconfig:"CARDANO_NODE_SOCKET_PATH"`
 	NetworkMagic      uint32               `yaml:"networkMagic"     envconfig:"CARDANO_NODE_NETWORK_MAGIC"`

--- a/main.go
+++ b/main.go
@@ -1220,6 +1220,7 @@ func getProcessMetricsByPidFile(cfg *config.Config, ctx context.Context) (*proce
 }
 
 func getProcessMetricsByNameAndPort(cfg *config.Config, ctx context.Context) (*process.Process, error) {
+	// TODO: assigning `r` here is triggering a golangci-lint failure
 	r, _ := process.NewProcessWithContext(ctx, 0)
 	processes, err := process.ProcessesWithContext(ctx)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -1197,11 +1197,12 @@ func getProcessMetricsByPidFile(cfg *config.Config, ctx context.Context) (*proce
 	if err != nil {
 		return nil, fmt.Errorf("invalid pid in pid file: %w", err)
 	}
-
 	if pid <= 0 || pid > math.MaxInt32 {
 		return nil, fmt.Errorf("invalid pid %d: out of int32 range", pid)
 	}
 
+	// the overflow is checked above
+	//nolint:gosec
 	proc, err := process.NewProcessWithContext(ctx, int32(pid))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get process %d: %w", pid, err)
@@ -1220,7 +1221,6 @@ func getProcessMetricsByPidFile(cfg *config.Config, ctx context.Context) (*proce
 }
 
 func getProcessMetricsByNameAndPort(cfg *config.Config, ctx context.Context) (*process.Process, error) {
-	// TODO: assigning `r` here is triggering a golangci-lint failure
 	r, _ := process.NewProcessWithContext(ctx, 0)
 	processes, err := process.ProcessesWithContext(ctx)
 	if err != nil {
@@ -1239,6 +1239,8 @@ func getProcessMetricsByNameAndPort(cfg *config.Config, ctx context.Context) (*p
 
 		if strings.Contains(n, cfg.Node.Binary) &&
 			strings.Contains(c, strconv.FormatUint(uint64(cfg.Node.Port), 10)) {
+			// TODO: linter thinks r = p here is ineffective, which it's not...
+			//nolint:ineffassign
 			r = p
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -1239,13 +1239,11 @@ func getProcessMetricsByNameAndPort(cfg *config.Config, ctx context.Context) (*p
 
 		if strings.Contains(n, cfg.Node.Binary) &&
 			strings.Contains(c, strconv.FormatUint(uint64(cfg.Node.Port), 10)) {
-			// TODO: linter thinks r = p here is ineffective, which it's not...
-			//nolint:ineffassign
 			r = p
 		}
 	}
 
-	return nil, fmt.Errorf("process containing binary '%s' and port '%d' not found", cfg.Node.Binary, cfg.Node.Port)
+	return r, nil
 }
 
 //nolint:unused

--- a/main.go
+++ b/main.go
@@ -1184,7 +1184,6 @@ func getProcessMetrics(ctx context.Context) (*process.Process, error) {
 	} else {
 		return getProcessMetricsByNameAndPort(cfg, ctx)
 	}
-
 }
 
 func getProcessMetricsByPidFile(cfg *config.Config, ctx context.Context) (*process.Process, error) {
@@ -1192,7 +1191,6 @@ func getProcessMetricsByPidFile(cfg *config.Config, ctx context.Context) (*proce
 	if err != nil {
 		return nil, fmt.Errorf("failed to read pid file: %w", err)
 	}
-
 	pidStr := strings.TrimSpace(string(data))
 	pid, err := strconv.Atoi(pidStr)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"math"
 	"net"
 	"os"
 	"strconv"
@@ -1195,6 +1196,10 @@ func getProcessMetricsByPidFile(cfg *config.Config, ctx context.Context) (*proce
 	pid, err := strconv.Atoi(pidStr)
 	if err != nil {
 		return nil, fmt.Errorf("invalid pid in pid file: %w", err)
+	}
+
+	if pid <= 0 || pid > math.MaxInt32 {
+		return nil, fmt.Errorf("invalid pid %d: out of int32 range", pid)
 	}
 
 	proc, err := process.NewProcessWithContext(ctx, int32(pid))

--- a/peers.go
+++ b/peers.go
@@ -41,6 +41,7 @@ func filterPeers(ctx context.Context) error {
 		len(peerStats.RTTresultsSlice) == len(peersFiltered) {
 		return nil
 	}
+
 	if processMetrics == nil {
 		return nil // TODO: what to do here
 	}

--- a/prometheus.go
+++ b/prometheus.go
@@ -97,6 +97,8 @@ func getPromMetrics(ctx context.Context) (*PromMetrics, error) {
 		failCount++
 		return metrics, fmt.Errorf("failed JSON unmarshal: %w", err)
 	}
+
+	// panic(string(b))
 	failCount = 0
 	return metrics, nil
 }


### PR DESCRIPTION
Read from a provided PID file when running with `amaru` as the binary name to get process metrics.

Otherwise, default to the (unchanged*) `cardano-node` behavior.

*I replaced errors with `continue`. That is changing the behavior, but I assumed that's the preferred behavior.