### PR TITLE
fix: skip unsupported metric types

### DIFF
--- a/prometheus.go
+++ b/prometheus.go
@@ -128,9 +128,11 @@ func prom2json(prom []byte) ([]byte, error) {
 			case dto.MetricType_SUMMARY,
 				dto.MetricType_HISTOGRAM,
 				dto.MetricType_GAUGE_HISTOGRAM:
-				return b, nil
+				// Skip unsupported metric types
+				break
 			default:
-				return b, nil
+				// Skip unknown types
+				break
 			}
 		}
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metric processing to continue handling supported types when encountering unsupported or unknown metric types, rather than halting early. Output now accumulates all supported metrics into the result.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->