### PR TITLE
feat: detect node type

### DIFF
--- a/node.go
+++ b/node.go
@@ -44,6 +44,13 @@ func setRole() {
 
 func getP2P(ctx context.Context, processMetrics *process.Process) bool {
 	cfg := config.GetConfig()
+
+	// Dingo and Amaru are always P2P
+	bin := getEffectiveNodeBinary()
+	if bin == DINGO_BINARY || bin == AMARU_BINARY {
+		return true
+	}
+
 	if cfg.Node.Network == "mainnet" {
 		if processMetrics == nil {
 			return p2p

--- a/prometheus_test.go
+++ b/prometheus_test.go
@@ -1,0 +1,158 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/nview/internal/config"
+)
+
+func TestDetectNodeType(t *testing.T) {
+	tests := []struct {
+		name             string
+		metrics          *PromMetrics
+		initialBinary    string
+		initialNodeName  string
+		expectedBinary   string
+		expectedNodeName string
+	}{
+		{
+			name: "Dingo detection with default node name",
+			metrics: &PromMetrics{
+				GoMemAlloc: 1000,
+				MemLive:    0,
+			},
+			initialBinary:    "",
+			initialNodeName:  "Cardano Node",
+			expectedBinary:   "dingo",
+			expectedNodeName: "Dingo",
+		},
+		{
+			name: "Dingo detection with custom node name",
+			metrics: &PromMetrics{
+				GoMemAlloc: 1000,
+				MemLive:    0,
+			},
+			initialBinary:    "",
+			initialNodeName:  "My Custom Node",
+			expectedBinary:   "dingo",
+			expectedNodeName: "My Custom Node",
+		},
+		{
+			name: "Cardano-node detection",
+			metrics: &PromMetrics{
+				GoMemAlloc: 0,
+				MemLive:    500,
+			},
+			initialBinary:    "",
+			initialNodeName:  "Cardano Node",
+			expectedBinary:   CARDANO_BINARY,
+			expectedNodeName: "Cardano Node",
+		},
+		{
+			name: "Cardano-node detection with MemLive > 0",
+			metrics: &PromMetrics{
+				GoMemAlloc: 1000,
+				MemLive:    500,
+			},
+			initialBinary:    "",
+			initialNodeName:  "Cardano Node",
+			expectedBinary:   CARDANO_BINARY,
+			expectedNodeName: "Cardano Node",
+		},
+		{
+			name: "Edge case: GoMemAlloc = 0, MemLive = 0",
+			metrics: &PromMetrics{
+				GoMemAlloc: 0,
+				MemLive:    0,
+			},
+			initialBinary:    "",
+			initialNodeName:  "Cardano Node",
+			expectedBinary:   CARDANO_BINARY,
+			expectedNodeName: "Cardano Node",
+		},
+		{
+			name: "User provided binary - don't override",
+			metrics: &PromMetrics{
+				GoMemAlloc: 1000,
+				MemLive:    0,
+			},
+			initialBinary:    "custom-node",
+			initialNodeName:  "Cardano Node",
+			expectedBinary:   "custom-node",
+			expectedNodeName: "Cardano Node",
+		},
+		{
+			name: "Amaru binary with default node name",
+			metrics: &PromMetrics{
+				GoMemAlloc: 1000,
+				MemLive:    0,
+			},
+			initialBinary:    "amaru",
+			initialNodeName:  "Cardano Node",
+			expectedBinary:   "amaru",
+			expectedNodeName: "Amaru",
+		},
+		{
+			name: "Amaru binary with custom node name",
+			metrics: &PromMetrics{
+				GoMemAlloc: 1000,
+				MemLive:    0,
+			},
+			initialBinary:    "amaru",
+			initialNodeName:  "My Custom Node",
+			expectedBinary:   "amaru",
+			expectedNodeName: "My Custom Node",
+		},
+		{
+			name:             "Nil metrics - early return",
+			metrics:          nil,
+			initialBinary:    "",
+			initialNodeName:  "Cardano Node",
+			expectedBinary:   "",
+			expectedNodeName: "Cardano Node",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset config and detected binary for each test
+			cfg := config.GetConfig()
+			cfg.Node.Binary = tt.initialBinary
+			cfg.App.NodeName = tt.initialNodeName
+			detectedNodeBinary.Store("") // Reset detected binary
+
+			// Call the function
+			detectNodeType(tt.metrics)
+
+			// Check results
+			if getEffectiveNodeBinary() != tt.expectedBinary {
+				t.Errorf(
+					"expected Binary %q, got %q",
+					tt.expectedBinary,
+					getEffectiveNodeBinary(),
+				)
+			}
+			if getEffectiveNodeName() != tt.expectedNodeName {
+				t.Errorf(
+					"expected NodeName %q, got %q",
+					tt.expectedNodeName,
+					getEffectiveNodeName(),
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION














<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-detect the node type (Dingo or cardano-node) from Prometheus metrics and adjust naming, resource stats, and UI accordingly. Standardized UI constants and improved P2P handling.

- **New Features**
  - Detect node binary once; use across UI/process metrics, display binary, and rename node to “Dingo” or “Amaru” when applicable.
  - For Dingo, show Go runtime memory (heap inuse/sys) and GC count; for cardano-node, keep MemLive/Heap and GC minor/major.
  - Treat Dingo and Amaru as always P2P.

- **Refactors**
  - Replaced magic numbers with constants for sizes, RTT thresholds, sync thresholds, terminal width, and progress bar granularity.
  - Use RTTUnreachable sentinel for peer display and a MillisecondsToSeconds constant for uptime.

<sup>Written for commit 604d6cf09b3c9bb3f180ac6efe1d92fd5dd0dc44. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->















<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic node-type detection with improved, user-visible node naming and a displayed effective node binary and uptime.

* **Bug Fixes**
  * Enforced P2P behavior for certain node types to stabilize networking.

* **Improvements**
  * Centralized UI thresholds and sizing for consistent RTT coloring, progress bars and layout.
  * Unified node-binary resolution and handling of node-specific memory/GC metrics.

* **Tests**
  * Added unit tests validating node-type detection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->