### PR TITLE
build: use go 1.25

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -33,3 +33,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.ref_type == 'tag' && github.ref_name || '' }}
+            COMMIT_HASH=${{ github.sha }}

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -16,7 +16,7 @@ jobs:
     name: go-test
     strategy:
       matrix:
-        go-version: [1.24.x, 1.25.x]
+        go-version: [1.25.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,7 @@ jobs:
           fetch-depth: '0'
       - uses: actions/setup-go@v6
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
       - name: Update GeoCity2-Lite DB
         if: startsWith(github.ref, 'refs/tags/')
         run: resources/update.sh
@@ -143,6 +143,9 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ env.RELEASE_TAG }}
+            COMMIT_HASH=${{ github.sha }}
       - name: Attest Docker Hub image
         uses: actions/attest-build-provenance@v3
         with:
@@ -163,7 +166,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: blinklabs/nview
           readme-filepath: ./README.md
-          short-description: "nview is a local monitoring tool for a Cardano Node"
+          short-description: "nview is a local monitoring tool for a Cardano node"
 
   finalize-release:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM ghcr.io/blinklabs-io/go:1.25.4-1 AS build
 
+ARG VERSION
+ARG COMMIT_HASH
+ENV VERSION=${VERSION}
+ENV COMMIT_HASH=${COMMIT_HASH}
+
 WORKDIR /code
 COPY . .
 RUN make build

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,10 @@ BINARIES=nview
 # Extract Go module name from go.mod
 GOMODULE=$(shell grep ^module $(ROOT_DIR)/go.mod | awk '{ print $$2 }')
 
-# Set version strings based on git tag and current ref
-GO_LDFLAGS=-ldflags "-s -w -X '$(GOMODULE)/internal/version.Version=$(shell git describe --tags --exact-match 2>/dev/null)' -X '$(GOMODULE)/internal/version.CommitHash=$(shell git rev-parse --short HEAD)'"
+# Set version strings: use env vars if set, else git
+VERSION ?= $(shell git describe --tags --exact-match 2>/dev/null)
+COMMIT_HASH ?= $(shell git rev-parse --short HEAD)
+GO_LDFLAGS=-ldflags "-s -w -X '$(GOMODULE)/internal/version.Version=$(VERSION)' -X '$(GOMODULE)/internal/version.CommitHash=$(COMMIT_HASH)'"
 
 .PHONY: build mod-tidy clean test
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/blinklabs-io/nview
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.24.4
+toolchain go1.25.4
 
 require (
 	github.com/gdamore/tcell/v2 v2.9.0


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade to Go 1.25 and wire version/commit metadata into builds so binaries and images report accurate version info. Updates CI, Docker, and Makefile to use env-provided VERSION and COMMIT_HASH.

- **Dependencies**
  - Bump Go to 1.25 (go.mod, toolchain 1.25.4).
  - Update Docker base image to go:1.25.4-1.
  - Use actions/setup-go 1.25.x in publish workflow.

- **Build/CI**
  - Add Docker build args VERSION and COMMIT_HASH; export in Dockerfile.
  - Makefile reads VERSION/COMMIT_HASH from env with git fallback; applied via -ldflags.
  - Workflows pass tag/SHA to builds; go-test now 1.25-only; fix Docker Hub short description casing.

<sup>Written for commit 0c9e9ffa7b4b74b5f38ee30b28e7296638844aed. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Go toolchain from version 1.24 to 1.25
  * Enhanced Docker images to automatically include version and commit information during builds
  * Improved build configuration for better artifact tracking and versioning

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->