### PR TITLE
build: use consistent versioning

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -6,7 +6,7 @@ on:
     paths: ['Dockerfile','*.go','go.*','.github/workflows/ci-docker.yml']
 
 env:
-  GHCR_IMAGE_NAME: ghcr.io/blinklabs-io/snek
+  GHCR_IMAGE_NAME: ghcr.io/blinklabs-io/nview
 
 permissions:
   contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -144,7 +144,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            VERSION=${{ env.RELEASE_TAG }}
+            VERSION=${{ github.ref_type == 'tag' && github.ref_name || '' }}
             COMMIT_HASH=${{ github.sha }}
       - name: Attest Docker Hub image
         uses: actions/attest-build-provenance@v3


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Align Docker workflows to use the correct GHCR image (nview) and set VERSION from the Git tag for consistent release versioning. This keeps image tags and build metadata in sync across releases.

- **Bug Fixes**
  - Use ghcr.io/blinklabs-io/nview in CI Docker workflow.
  - Derive VERSION from tag refs (github.ref_name) instead of RELEASE_TAG to avoid stale or mismatched versions.

<sup>Written for commit c8ae74885aadc86c2d8c2edf4530e39a0a50a23d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

