### PR TITLE
chore: remove unused legacy path

### DIFF
--- a/main.go
+++ b/main.go
@@ -682,14 +682,8 @@ func getEpochText(ctx context.Context) string {
 	granularity := ProgressBarGranularity
 	var charMarked string
 	var charUnmarked string
-	// TODO: legacy mode vs new
-	if false {
-		charMarked = string('#')
-		charUnmarked = string('.')
-	} else {
-		charMarked = string('▌')
-		charUnmarked = string('▖')
-	}
+	charMarked = string('▌')
+	charUnmarked = string('▖')
 
 	epochItems := int(epochProgress) * granularity / 100
 	if epochItems != epochItemsLast {
@@ -1104,14 +1098,8 @@ func getPeerText(ctx context.Context) string {
 
 	var charMarked string
 	var charUnmarked string
-	// TODO: legacy mode vs new
-	if false {
-		charMarked = string('#')
-		charUnmarked = string('.')
-	} else {
-		charMarked = string('▌')
-		charUnmarked = string('▖')
-	}
+	charMarked = string('▌')
+	charUnmarked = string('▖')
 	granularity := ProgressBarGranularity
 	granularitySmall := granularity / 2
 	if checkPeers {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the unused legacy progress bar path and simplified character selection in getEpochText and getPeerText to always use '▌' and '▖'. No functional change; this removes dead code and reduces branching.

<sup>Written for commit b22e17a66de41d2c89d499f5efec81ddf2ed6dfb. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

