### PR TITLE
fix: improve peer filtering logic and error handling

### DIFF
--- a/peers.go
+++ b/peers.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"sort"
@@ -43,7 +44,7 @@ func filterPeers(ctx context.Context) error {
 	}
 
 	if processMetrics == nil {
-		return nil // TODO: what to do here
+		return errors.New("process metrics not available for peer filtering")
 	}
 	cfg := config.GetConfig()
 
@@ -166,8 +167,7 @@ func filterPeers(ctx context.Context) error {
 			}
 		}
 	}
-	// TODO: do this better than just a length check
-	if len(peers) != len(peersFiltered) {
+	if !slices.Equal(peers, peersFiltered) {
 		peersFiltered = peers
 	}
 	return nil


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Return an explicit error when process metrics are missing, and fix peer filtering by comparing slices instead of lengths.
This prevents silent failures and ensures the filtered peer list resets only when the actual contents differ.

<sup>Written for commit 34fd810581e1fcc1af430c8d965ceb45ed6ea66d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to prevent failures when process metrics are unavailable
  * Enhanced reliability of peer list change detection with more accurate comparison logic

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->