### PR TITLE
feat: add configurable log buffer for exit display

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,10 +30,11 @@ type Config struct {
 }
 
 type AppConfig struct {
-	NodeName string `yaml:"nodeName" envconfig:"NODE_NAME"`
-	Network  string `yaml:"network"  envconfig:"NETWORK"`
-	Refresh  uint32 `yaml:"refresh"  envconfig:"REFRESH"`
-	Retries  uint32 `yaml:"retries"  envconfig:"RETRIES"`
+	NodeName      string `yaml:"nodeName"      envconfig:"NODE_NAME"`
+	Network       string `yaml:"network"       envconfig:"NETWORK"`
+	Refresh       uint32 `yaml:"refresh"       envconfig:"REFRESH"`
+	Retries       uint32 `yaml:"retries"       envconfig:"RETRIES"`
+	LogBufferSize uint32 `yaml:"logBufferSize" envconfig:"LOG_BUFFER_SIZE"`
 }
 
 type NodeConfig struct {
@@ -72,10 +73,11 @@ type ShelleyGenesisConfig struct {
 func getDefaultConfig() *Config {
 	return &Config{
 		App: AppConfig{
-			NodeName: "Cardano Node",
-			Network:  "",
-			Refresh:  1,
-			Retries:  3,
+			NodeName:      "Cardano Node",
+			Network:       "",
+			Refresh:       1,
+			Retries:       3,
+			LogBufferSize: 1000,
 		},
 		Node: NodeConfig{
 			Binary:            "cardano-node",

--- a/utils.go
+++ b/utils.go
@@ -17,7 +17,6 @@ package main
 import (
 	"context"
 	_ "embed"
-	"errors"
 	"fmt"
 	"net"
 	"os/exec"
@@ -31,7 +30,11 @@ func getNodeVersion() (version string, revision string, err error) {
 	cmd := exec.Command(getEffectiveNodeBinary(), "version") // #nosec G204
 	stdout, err := cmd.Output()
 	if err != nil {
-		return "N/A", "N/A", err
+		return "N/A", "N/A", fmt.Errorf(
+			"failed to execute %s version command: %w",
+			getEffectiveNodeBinary(),
+			err,
+		)
 	}
 	output := strings.TrimSpace(string(stdout))
 
@@ -55,7 +58,11 @@ func getNodeVersion() (version string, revision string, err error) {
 	// Handle cardano-node format (fallback)
 	strArray := strings.Split(output, " ")
 	if len(strArray) < 8 {
-		return "N/A", "N/A", errors.New("unexpected version format")
+		return "N/A", "N/A", fmt.Errorf(
+			"unexpected version format from %s: output has %d parts, expected at least 8",
+			getEffectiveNodeBinary(),
+			len(strArray),
+		)
 	}
 	version = strArray[1]
 	revision = strArray[7]


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a configurable log buffer that captures recent logs and prints them on exit to help with troubleshooting. Logs still go to stderr, and the buffer size is configurable (default 1000).

- **New Features**
  - Added AppConfig.LogBufferSize (env LOG_BUFFER_SIZE, default 1000).
  - Implemented a buffered slog handler that mirrors logs to stderr and stores the last N entries.
  - Prints buffered logs on exit (q or Esc) under "Application Logs".
  - Added warning logs for Prometheus fetch, peer filtering, and ping failures.

- **Refactors**
  - Switched to slog for structured logging in main.
  - Improved getNodeVersion errors with clearer, contextual messages.

<sup>Written for commit 831dcb40f289800116ba310d7c74760a0c2f192b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented configurable in-memory log buffering with structured logging for improved diagnostics.
  * Application now displays accumulated logs upon exit for debugging.

* **Bug Fixes**
  * Enhanced error messages with more detailed diagnostic context.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->