### PR TITLE
docs: enhance documentation and API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 # nview
 
-nview is a local monitoring tool for a Cardano Node (cardano-node) meant to
-complement remote monitoring tools by providing a local view of a running
-node from the command line. It's a TUI (terminal user interface) designed to
-fit most screens.
+[![CI](https://github.com/blinklabs-io/nview/actions/workflows/go-test.yml/badge.svg)](https://github.com/blinklabs-io/nview/actions/workflows/go-test.yml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/blinklabs-io/nview)](https://goreportcard.com/report/github.com/blinklabs-io/nview)
+[![Go Version](https://img.shields.io/badge/go-1.25+-blue.svg)](https://golang.org)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/blinklabs-io/nview/blob/main/LICENSE)
+
+nview is a local monitoring tool for Cardano nodes, supporting multiple
+implementations including cardano-node, Dingo, and Amaru. It's designed to
+complement remote monitoring tools by providing a local command-line view of
+running nodes. The TUI (terminal user interface) is built to fit most screens
+and provides real-time metrics and status information.
 
 <div align="center">
     <img src="./nview-20240208.png" alt="nview screenshot" width="640">
@@ -23,11 +29,24 @@ application from being a drop-in replacement for gLiveView for Cardano Node
 administrators, but unlocks the ability to add functionality beyond that
 easily attainable with a shell script.
 
+### Multi-Implementation Support
+
+nview automatically detects and supports multiple Cardano node implementations:
+
+- **cardano-node**: The official Cardano node implementation
+- **Dingo**: A Cardano node implementation focused on performance
+- **Amaru**: Another Cardano node implementation with specific optimizations
+
+The tool automatically detects the running node type based on Prometheus metrics
+and adjusts its display accordingly. No configuration changes are needed - just
+run nview against any supported Cardano node.
+
 ## Usage
 
 Running nview against a running Cardano Node will work out of the box with a
 default Cardano Node configuration, which exposes metrics in Prometheus data
-format on a specific port.
+format on a specific port. nview automatically detects the node implementation
+(cardano-node, Dingo, or Amaru) and adjusts its display accordingly.
 
 ```bash
 ./nview
@@ -54,6 +73,9 @@ The following environment variables control the behavior of the application.
   for the given known named network. Overrides `CARDANO_NETWORK`, default ""
 - `CARDANO_NETWORK` - Named network configured on the Cardano Node, default
   is "mainnet"
+- `CARDANO_NODE_BINARY` - Specifies the node binary type
+  (`cardano-node`, `dingo`, or `amaru`). If not set, nview will attempt to
+  auto-detect based on metrics
 - `PROM_HOST` - Sets the host address used to fetch Prometheus metrics from a
   Cardano Node, default is "127.0.0.1"
 - `PROM_PORT` - Sets the host port used to fetch Prometheus metrics from a
@@ -76,6 +98,7 @@ app:
   nodeName: Cardano Node
   network:
 node:
+  binary: cardano-node  # or 'dingo' or 'amaru'
   network: mainnet
   port: 3001
 prometheus:
@@ -85,6 +108,62 @@ prometheus:
 ```
 
 An example configuration is provided at `config.yaml.example`.
+
+## Examples
+
+### Running with Dingo Node
+
+```bash
+# Auto-detection (recommended)
+./nview
+
+# Or explicitly set
+CARDANO_NODE_BINARY=dingo ./nview
+```
+
+### Running with Amaru Node
+
+```bash
+# Auto-detection (recommended)
+./nview
+
+# Or explicitly set
+CARDANO_NODE_BINARY=amaru ./nview
+```
+
+### Custom Prometheus Port
+
+```bash
+PROM_PORT=9090 ./nview
+```
+
+### Remote Node Monitoring
+
+```bash
+PROM_HOST=192.168.1.100 PROM_PORT=12798 ./nview
+```
+
+## Troubleshooting
+
+### Node Not Detected
+
+If nview shows "Cardano Node" instead of the expected implementation:
+
+1. Ensure your node is running and exposing Prometheus metrics
+2. Check that the correct `PROM_HOST` and `PROM_PORT` are set
+3. For manual override, set `CARDANO_NODE_BINARY` environment variable
+
+### Connection Issues
+
+- Verify Prometheus metrics are accessible: `curl http://127.0.0.1:12798/metrics`
+- Check firewall settings if monitoring remotely
+- Increase timeout if on slow networks: `PROM_TIMEOUT=10 ./nview`
+
+### Display Issues
+
+- Ensure terminal supports Unicode characters
+- Check terminal width (minimum 112 columns recommended)
+- For color issues, ensure terminal supports 256 colors
 
 ## GeoLocation
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -71,3 +71,22 @@ prometheus:
   #
   # This can also be set via the PROM_TIMEOUT environment variable
   timeout: 3
+
+# Example configurations for different node implementations:
+#
+# For Dingo:
+# node:
+#   binary: dingo
+#   network: mainnet
+#
+# For Amaru:
+# node:
+#   binary: amaru
+#   network: mainnet
+#   pidFile: /path/to/amaru.pid  # Required for Amaru
+#
+# For custom Prometheus port:
+# prometheus:
+#   host: 127.0.0.1
+#   port: 9090
+#   timeout: 5

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,12 +23,15 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// Config represents the complete configuration structure for nview.
+// It contains application settings, node configuration, and Prometheus settings.
 type Config struct {
 	App        AppConfig        `yaml:"app"`
 	Node       NodeConfig       `yaml:"node"`
 	Prometheus PrometheusConfig `yaml:"prometheus"`
 }
 
+// AppConfig contains application-level configuration options.
 type AppConfig struct {
 	NodeName      string `yaml:"nodeName"      envconfig:"NODE_NAME"`
 	Network       string `yaml:"network"       envconfig:"NETWORK"`
@@ -37,6 +40,7 @@ type AppConfig struct {
 	LogBufferSize uint32 `yaml:"logBufferSize" envconfig:"LOG_BUFFER_SIZE"`
 }
 
+// NodeConfig contains configuration specific to the Cardano node being monitored.
 type NodeConfig struct {
 	ByronGenesis      ByronGenesisConfig   `yaml:"byron"`
 	Binary            string               `yaml:"binary"           envconfig:"CARDANO_NODE_BINARY"`
@@ -49,6 +53,7 @@ type NodeConfig struct {
 	BlockProducer     bool                 `yaml:"blockProducer"    envconfig:"CARDANO_BLOCK_PRODUCER"`
 }
 
+// PrometheusConfig contains settings for connecting to the node's Prometheus metrics endpoint.
 type PrometheusConfig struct {
 	Host    string `yaml:"host"    envconfig:"PROM_HOST"`
 	Port    uint32 `yaml:"port"    envconfig:"PROM_PORT"`
@@ -56,6 +61,7 @@ type PrometheusConfig struct {
 	Timeout uint32 `yaml:"timeout" envconfig:"PROM_TIMEOUT"`
 }
 
+// ByronGenesisConfig contains Byron-era genesis parameters.
 type ByronGenesisConfig struct {
 	StartTime   uint64 `yaml:"startTime"   envconfig:"BYRON_GENESIS_START_SEC"`
 	EpochLength uint64 `yaml:"epochLength" envconfig:"BYRON_EPOCH_LENGTH"`
@@ -63,6 +69,7 @@ type ByronGenesisConfig struct {
 	SlotLength  uint64 `yaml:"slotLength"  envconfig:"BYRON_SLOT_LENGTH"`
 }
 
+// ShelleyGenesisConfig contains Shelley-era genesis parameters.
 type ShelleyGenesisConfig struct {
 	EpochLength       uint64 `yaml:"epochLength"       envconfig:"SHELLEY_EPOCH_LENGTH"`
 	SlotLength        uint64 `yaml:"slotLength"        envconfig:"SHELLEY_SLOT_LENGTH"`
@@ -97,6 +104,9 @@ func getDefaultConfig() *Config {
 // Singleton config instance with default values
 var globalConfig = getDefaultConfig()
 
+// LoadConfig loads configuration from a YAML file and environment variables.
+// Environment variables take precedence over file values. If configFile is empty,
+// only environment variables and defaults are used.
 func LoadConfig(configFile string) (*Config, error) {
 	cfg := getDefaultConfig()
 	// Load config file as YAML if provided
@@ -138,7 +148,8 @@ func LoadConfig(configFile string) (*Config, error) {
 	return cfg, nil
 }
 
-// GetConfig returns the global config instance
+// GetConfig returns the global config instance.
+// This is a singleton accessor for the loaded configuration.
 func GetConfig() *Config {
 	return globalConfig
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -24,6 +24,8 @@ var (
 	CommitHash string
 )
 
+// GetVersionString returns a formatted version string including the commit hash.
+// If Version is not set (development builds), it returns "devel" with the commit hash.
 func GetVersionString() string {
 	if Version != "" {
 		return fmt.Sprintf("%s (commit %s)", Version, CommitHash)

--- a/prometheus.go
+++ b/prometheus.go
@@ -42,6 +42,9 @@ func setCurrentEpoch() {
 
 var promMetrics *PromMetrics
 
+// PromMetrics holds all the Prometheus metrics collected from a Cardano node.
+// It includes metrics for blocks, epochs, slots, memory, connections, and more.
+// The struct fields are tagged with JSON names corresponding to Prometheus metric names.
 type PromMetrics struct {
 	BlockNum            uint64  `json:"cardano_node_metrics_blockNum_int"`
 	EpochNum            uint64  `json:"cardano_node_metrics_epoch_int"`


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expanded documentation and API docs to clarify multi-implementation support (cardano-node, Dingo, Amaru), add usage examples and troubleshooting, and document env/config options like CARDANO_NODE_BINARY. Added inline Go comments for config structs, version string, and Prometheus metrics to improve API clarity.

<sup>Written for commit 9e64afe899947e6077f04f0bfb46b9fd3a1f1f35. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

