### PR TITLE
feat: support providing node PID

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -60,6 +60,18 @@ node:
   # This can also be set via the CARDANO_NODE_PID_FILE environment variable
   pidFile:
 
+  # PID for the node process
+  #
+  # When set to a non-zero value, this bypasses all automatic PID detection
+  # mechanisms and directly uses the specified PID for process metrics.
+  #
+  # - For cardano-node: Bypasses name/port-based detection
+  # - For Dingo: Overrides the default PID 1 (when set to non-zero)
+  # - For Amaru: Skips reading from pidFile and uses this PID directly
+  #
+  # This can also be set via the CARDANO_NODE_PID environment variable
+  pid: 0
+
 prometheus:
   # host/port for the node Prometheus metrics
   #
@@ -79,11 +91,30 @@ prometheus:
 #   binary: dingo
 #   network: mainnet
 #
+# For Dingo with custom PID:
+# node:
+#   binary: dingo
+#   network: mainnet
+#   pid: 1234  # Override default PID 1
+#
 # For Amaru:
 # node:
 #   binary: amaru
 #   network: mainnet
 #   pidFile: /path/to/amaru.pid  # Required for Amaru
+#
+# For Amaru with direct PID (skips pidFile):
+# node:
+#   binary: amaru
+#   network: mainnet
+#   pid: 5678  # Use this PID directly, ignore pidFile
+#
+# For cardano-node with direct PID:
+# node:
+#   binary: cardano-node
+#   network: mainnet
+#   port: 3001
+#   pid: 9999  # Bypass name/port detection
 #
 # For custom Prometheus port:
 # prometheus:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,6 +44,7 @@ type AppConfig struct {
 type NodeConfig struct {
 	ByronGenesis      ByronGenesisConfig   `yaml:"byron"`
 	Binary            string               `yaml:"binary"           envconfig:"CARDANO_NODE_BINARY"`
+	Pid               int32                `yaml:"pid"              envconfig:"CARDANO_NODE_PID"`
 	PidFile           string               `yaml:"pidFile"          envconfig:"CARDANO_NODE_PID_FILE"`
 	Network           string               `yaml:"network"          envconfig:"CARDANO_NETWORK"`
 	NetworkMagic      uint32               `yaml:"networkMagic"     envconfig:"CARDANO_NODE_NETWORK_MAGIC"`

--- a/main.go
+++ b/main.go
@@ -1438,6 +1438,11 @@ func getResourceText(ctx context.Context) string {
 func getProcessMetrics(ctx context.Context) (*process.Process, error) {
 	cfg := config.GetConfig()
 
+	// If CARDANO_NODE_PID is specified, use it directly for all node types
+	if cfg.Node.Pid > 0 {
+		return getProcessMetricsByPid(ctx, cfg.Node.Pid)
+	}
+
 	switch getEffectiveNodeBinary() {
 	case AMARU_BINARY:
 		return getProcessMetricsByPidFile(ctx, cfg)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add support for explicitly setting the node PID, letting us bypass auto-detection and read process metrics directly. This improves reliability across cardano-node, Dingo, and Amaru.

- **New Features**
  - Added node.pid to config and CARDANO_NODE_PID env var.
  - If pid > 0, main uses it directly and skips name/port or pidFile detection.
  - Works across binaries:
    - cardano-node: bypasses name/port detection
    - Dingo: overrides default PID 1
    - Amaru: skips pidFile
  - Updated config.yaml.example with usage examples.

<sup>Written for commit 2953abc1327227f781f5ca24d9690cc0f5eafd4b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configuration option to specify a node process ID directly via the `node.pid` setting or `CARDANO_NODE_PID` environment variable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->