### PR TITLE
feat: improve Dingo process detection

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -1447,8 +1448,16 @@ func getProcessMetrics(ctx context.Context) (*process.Process, error) {
 	case AMARU_BINARY:
 		return getProcessMetricsByPidFile(ctx, cfg)
 	case DINGO_BINARY:
-		// Dingo is assumed to run as PID 1 in containerized environments
-		return getProcessMetricsByPid(ctx, 1)
+		// Use configured PID, defaulting to 1 if not set
+		pid := cfg.Node.Pid
+		if pid == 0 {
+			pid = 1
+		}
+		if proc, err := getProcessMetricsByPid(ctx, pid); err == nil {
+			return proc, nil
+		}
+		// Fall back to name-based search
+		return getProcessMetricsByName(ctx, cfg)
 	default:
 		return getProcessMetricsByNameAndPort(ctx, cfg)
 	}
@@ -1521,6 +1530,47 @@ func getProcessMetricsByPidFile(
 	}
 
 	return proc, nil
+}
+
+func getProcessMetricsByName(
+	ctx context.Context,
+	cfg *config.Config,
+) (*process.Process, error) {
+	r, _ := process.NewProcessWithContext(ctx, 0)
+	processes, err := process.ProcessesWithContext(ctx)
+	if err != nil {
+		return r, fmt.Errorf("failed to get processes: %w", err)
+	}
+	for _, p := range processes {
+		n, err := p.NameWithContext(ctx)
+		if err != nil {
+			continue
+		}
+
+		if strings.Contains(n, getEffectiveNodeBinary()) {
+			r = p
+			break
+		}
+	}
+
+	// Check if we found a process
+	if r == nil || r.Pid == 0 {
+		return r, fmt.Errorf(
+			"no process found with name containing %s",
+			getEffectiveNodeBinary(),
+		)
+	}
+
+	exists, err := r.IsRunning()
+	if err != nil {
+		return r, fmt.Errorf("failed to check if process is running: %w", err)
+	}
+
+	if !exists {
+		return r, errors.New("process is not running")
+	}
+
+	return r, nil
 }
 
 func getProcessMetricsByNameAndPort(


### PR DESCRIPTION
Add CARDANO_NODE_PID support with fallback to PID 1 and name-based search

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve Dingo process detection by supporting CARDANO_NODE_PID with a fallback to PID 1 and a name-based search to reliably find the running node.

- **New Features**
  - Use CARDANO_NODE_PID (cfg.Node.Pid), defaulting to PID 1 when unset.
  - If PID lookup fails, search processes by the effective node binary name and confirm the process is running.
  - Added getProcessMetricsByName with clear error handling.

<sup>Written for commit 0abb0d9e1dde03773a39fb6e7b0a292a8962d4da. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Improved process detection reliability for monitoring operations. The system now employs multiple intelligent lookup strategies with automatic fallbacks to correctly identify node processes in various configurations. This particularly benefits complex environments where default identification assumptions don't apply, while explicit configuration settings remain fully supported.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->