### PR TITLE
fix: remove binary name from node section

### DIFF
--- a/main.go
+++ b/main.go
@@ -1134,12 +1134,6 @@ func getNodeText(ctx context.Context) string {
 			nodeRevision,
 		),
 	))
-	sb.WriteString(
-		fmt.Sprintf(
-			" [green]Binary     : [white]%s\n",
-			getEffectiveNodeBinary(),
-		),
-	)
 	if publicIP != nil {
 		sb.WriteString(
 			fmt.Sprintf(" [green]Public IP  : [white]%s\n", publicIP),


### PR DESCRIPTION
This keeps uptime from falling outside the visual space.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the Binary name display from the node section to prevent UI overflow. This keeps the uptime line within the visible area.

<sup>Written for commit 2a6288dc31739c8ffb53293c37733a86f606845a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed extraneous node binary information from the Node section output, streamlining displayed details.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->