### PR TITLE
ci(workflow):update-closed-issues

### DIFF
--- a/.github/workflows/test-issue-on-close.yml
+++ b/.github/workflows/test-issue-on-close.yml
@@ -1,0 +1,23 @@
+name: Test Issue Close Trigger
+permissions:
+  contents: read
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print closed issue info
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+        run: |
+          echo "Issue Number: $ISSUE_NUMBER"
+          # Prevent workflow command injection from untrusted issue titles
+          TOKEN=$(uuidgen)
+          echo "::stop-commands::${TOKEN}"
+          echo "Title: $ISSUE_TITLE"
+          echo "::${TOKEN}::"
+          echo "Workflow triggered successfully when issue was closed."

--- a/.github/workflows/update-issue-on-close.yml
+++ b/.github/workflows/update-issue-on-close.yml
@@ -1,0 +1,39 @@
+name: Set Project Closed Date
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  contents: read
+  issues: read
+
+env:
+  PROJECT_URL: https://github.com/orgs/blinklabs-io/projects/11
+  CLOSED_DATE_FIELD: "Closed Date"
+
+jobs:
+  set-date:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve closed date
+        id: when
+        shell: bash
+        run: |
+          ts='${{ github.event.issue.closed_at }}'
+          if [ -z "$ts" ] || [ "$ts" = "null" ]; then
+            echo "Error: closed_at timestamp is missing or null. Refusing to set an incorrect closed date." >&2
+            exit 1
+          fi
+          d=$(date -u -d "$ts" +%F)
+          echo "date=$d" >> "$GITHUB_OUTPUT"
+          echo "Closed date -> $d"
+
+      # Update the "Closed Date" field on that project item
+      - name: Update Closed Date field
+        uses: nipe0324/update-project-v2-item-field@c4af58452d1c5a788c1ea4f20e073fa722ec4a6b
+        with:
+          project-url: ${{ env.PROJECT_URL }}
+          github-token: ${{ secrets.ORG_PROJECT_PAT }}
+          field-name: ${{ env.CLOSED_DATE_FIELD }}
+          field-value: ${{ steps.when.outputs.date }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds two GitHub Actions that run when an issue is closed: a safety-checked test logger and an updater that sets the project’s “Closed Date” from the issue’s closed_at timestamp.

- **New Features**
  - Test workflow prints the closed issue number and title safely (prevents workflow command injection).
  - Update workflow resolves the UTC date from `closed_at` and sets the “Closed Date” field via `nipe0324/update-project-v2-item-field`.

- **Migration**
  - Configure the `ORG_PROJECT_PAT` org secret with Projects v2 write access for the target project.

<sup>Written for commit 91a3fc6baa0e67320fbd41966eec98a5ef32d787. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated workflows to improve issue management processes.
  * Enhanced project tracking with automatic closed date updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->