### PR TITLE
fix: epoch progress bar flicker

### DIFF
--- a/main.go
+++ b/main.go
@@ -696,9 +696,6 @@ func getUptimes(ctx context.Context, processMetrics *process.Process) uint64 {
 	return uptimes
 }
 
-// Track size of epoch items
-var epochItemsLast = 0
-
 func getEpochProgress() float32 {
 	cfg := config.GetConfig()
 	if cfg.Node.ShelleyTransEpoch < 0 {
@@ -747,20 +744,15 @@ func getEpochText(ctx context.Context) string {
 	// Epoch progress bar
 	var epochBar strings.Builder
 	granularity := ProgressBarGranularity
-	var charMarked string
-	var charUnmarked string
-	charMarked = string('▌')
-	charUnmarked = string('▖')
+	charMarked := string('▌')
+	charUnmarked := string('▖')
 
 	epochItems := int(epochProgress) * granularity / 100
-	if epochItems != epochItemsLast {
-		epochItemsLast = epochItems
-		for i := 0; i <= granularity-1; i++ {
-			if i < epochItems {
-				epochBar.WriteString("[blue]" + charMarked)
-			} else {
-				epochBar.WriteString("[white]" + charUnmarked)
-			}
+	for i := 0; i <= granularity-1; i++ {
+		if i < epochItems {
+			epochBar.WriteString("[blue]" + charMarked)
+		} else {
+			epochBar.WriteString("[white]" + charUnmarked)
 		}
 	}
 	fmt.Fprintf(&sb, " [blue]%s[green]\n", epochBar.String())
@@ -872,7 +864,8 @@ func getConnectionText(ctx context.Context) string {
 		// Get process in/out connections
 		connections, err := netutil.ConnectionsPidWithContext(ctx, "tcp", processMetrics.Pid)
 		if err != nil {
-			fmt.Fprintf(&sb, "Failed to get processes: %v", err)
+			fmt.Fprintf(os.Stderr, "Failed to get processes: %v\n", err)
+			return connectionText
 		}
 
 		var peersIn []string


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flicker in the epoch progress bar by rebuilding it on every refresh with no cached state. Hardens connection stats by logging lookup errors to stderr and returning the last valid output.

- **Bug Fixes**
  - Remove `epochItemsLast` and always rebuild the epoch bar to prevent stale frames/flicker.
  - On `netutil.ConnectionsPidWithContext` errors, write to `stderr` and return the prior `connectionText` instead of rendering incomplete data.

<sup>Written for commit dc643a16ad9deb50a5e2acf313af0ae9f3782a23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Connection status handling improved — when retrieving connection info fails, the display now keeps the previous valid information instead of showing partial or error text.

* **Refactor**
  * Epoch progress bar logic simplified so it's rebuilt consistently on update; internal variable handling streamlined for maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->