### PR TITLE
feat(config): Derive Shelley genesis from dingo_shelley_start_time /dingo_epoch_length_slots

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sync/atomic"
 
 	"github.com/kelseyhightower/envconfig"
 	"gopkg.in/yaml.v2"
@@ -104,9 +105,13 @@ func getDefaultConfig() *Config {
 
 // Singleton config instance with default values
 var (
-	globalConfig              = getDefaultConfig()
-	defaultsForCurrentNetwork = getDefaultConfig()
+	globalConfig              atomic.Pointer[Config]
+	defaultsForCurrentNetwork atomic.Pointer[Config]
 )
+
+func init() {
+	globalConfig.Store(getDefaultConfig())
+}
 
 // LoadConfig loads configuration from a YAML file and environment variables.
 // Environment variables take precedence over file values. If configFile is empty,
@@ -152,15 +157,19 @@ func LoadConfig(configFile string) (*Config, error) {
 		return nil, err
 	}
 	// Update global config for singleton access
-	globalConfig = cfg
-	defaultsForCurrentNetwork = defaults
+	globalConfig.Store(cfg)
+	defaultsForCurrentNetwork.Store(defaults)
 	return cfg, nil
 }
 
 // GetConfig returns the global config instance.
 // This is a singleton accessor for the loaded configuration.
 func GetConfig() *Config {
-	return globalConfig
+	cfg := globalConfig.Load()
+	if cfg == nil {
+		return getDefaultConfig()
+	}
+	return cfg
 }
 
 func (c *Config) defaultConfigForCurrentNetwork() (*Config, error) {
@@ -202,18 +211,19 @@ func ApplyDingoGenesisOverride(shelleyStart, epochLenSlots uint64) bool {
 		return false
 	}
 	// Nothing to compare against if config has not been loaded yet.
-	if defaultsForCurrentNetwork == nil || globalConfig == nil {
+	cfg := globalConfig.Load()
+	defaults := defaultsForCurrentNetwork.Load()
+	if defaults == nil || cfg == nil {
 		return false
 	}
 
-	cfg := globalConfig
-	defaults := defaultsForCurrentNetwork
 	// Only override values that still match the network-table defaults.
 	if cfg.Node.ByronGenesis.StartTime != defaults.Node.ByronGenesis.StartTime ||
 		cfg.Node.ByronGenesis.EpochLength != defaults.Node.ByronGenesis.EpochLength ||
 		cfg.Node.ByronGenesis.SlotLength != defaults.Node.ByronGenesis.SlotLength ||
 		cfg.Node.ShelleyGenesis.EpochLength != defaults.Node.ShelleyGenesis.EpochLength ||
-		cfg.Node.ShelleyGenesis.SlotLength != defaults.Node.ShelleyGenesis.SlotLength {
+		cfg.Node.ShelleyGenesis.SlotLength != defaults.Node.ShelleyGenesis.SlotLength ||
+		cfg.Node.ShelleyTransEpoch != defaults.Node.ShelleyTransEpoch {
 		return false
 	}
 
@@ -221,9 +231,11 @@ func ApplyDingoGenesisOverride(shelleyStart, epochLenSlots uint64) bool {
 		cfg.Node.ShelleyGenesis.EpochLength != epochLenSlots ||
 		cfg.Node.ShelleyTransEpoch != 0
 
-	cfg.Node.ByronGenesis.StartTime = shelleyStart
-	cfg.Node.ShelleyGenesis.EpochLength = epochLenSlots
-	cfg.Node.ShelleyTransEpoch = 0
+	updated := *cfg
+	updated.Node.ByronGenesis.StartTime = shelleyStart
+	updated.Node.ShelleyGenesis.EpochLength = epochLenSlots
+	updated.Node.ShelleyTransEpoch = 0
+	globalConfig.Store(&updated)
 	return changed
 }
 
@@ -299,8 +311,10 @@ func (c *Config) populateByronGenesis() error {
 		c.Node.ByronGenesis.SlotLength = 20000
 	}
 	// Our K is 2160, except preview, which we'll override below
+	kWasDefaulted := false
 	if c.Node.ByronGenesis.K == 0 {
 		c.Node.ByronGenesis.K = 2160
+		kWasDefaulted = true
 	}
 
 	network := c.Node.Network
@@ -313,7 +327,7 @@ func (c *Config) populateByronGenesis() error {
 
 	switch network {
 	case "preview":
-		if c.Node.ByronGenesis.K == 2160 {
+		if kWasDefaulted {
 			c.Node.ByronGenesis.K = 432
 		}
 		if c.Node.ByronGenesis.StartTime == 0 {
@@ -324,7 +338,7 @@ func (c *Config) populateByronGenesis() error {
 			c.Node.ByronGenesis.StartTime = 1654041600
 		}
 	case "sancho":
-		if c.Node.ByronGenesis.K == 2160 {
+		if kWasDefaulted {
 			c.Node.ByronGenesis.K = 432
 		}
 		if c.Node.ByronGenesis.StartTime == 0 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -104,6 +104,7 @@ func getDefaultConfig() *Config {
 
 // Singleton config instance with default values
 var globalConfig = getDefaultConfig()
+var defaultsForCurrentNetwork = getDefaultConfig()
 
 // LoadConfig loads configuration from a YAML file and environment variables.
 // Environment variables take precedence over file values. If configFile is empty,
@@ -144,8 +145,13 @@ func LoadConfig(configFile string) (*Config, error) {
 	if err := cfg.populateShelleyTransEpoch(); err != nil {
 		return nil, err
 	}
+	defaults, err := cfg.defaultConfigForCurrentNetwork()
+	if err != nil {
+		return nil, err
+	}
 	// Update global config for singleton access
 	globalConfig = cfg
+	defaultsForCurrentNetwork = defaults
 	return cfg, nil
 }
 
@@ -153,6 +159,70 @@ func LoadConfig(configFile string) (*Config, error) {
 // This is a singleton accessor for the loaded configuration.
 func GetConfig() *Config {
 	return globalConfig
+}
+
+func (c *Config) defaultConfigForCurrentNetwork() (*Config, error) {
+	defaults := getDefaultConfig()
+	defaults.App.Network = c.App.Network
+	defaults.Node.Network = c.Node.Network
+	defaults.Node.NetworkMagic = c.Node.NetworkMagic
+
+	if err := defaults.populateNetworkMagic(); err != nil {
+		return nil, err
+	}
+	if err := defaults.populateByronGenesis(); err != nil {
+		return nil, err
+	}
+	if err := defaults.populateShelleyGenesis(); err != nil {
+		return nil, err
+	}
+	if err := defaults.populateShelleyTransEpoch(); err != nil {
+		return nil, err
+	}
+	return defaults, nil
+}
+
+// ApplyDingoGenesisOverride mutates the singleton config when Dingo metrics
+// supersede the hardcoded network table. Dingo devnets usually have no Byron
+// era, so the Shelley start time is used as the effective Byron start time and
+// ShelleyTransEpoch is forced to 0. This makes existing slot math compute pure
+// Shelley-era slots for those networks.
+//
+// Only fires when:
+//   - both metric values are non-zero
+//   - the corresponding config fields still match the network-table defaults
+//     (i.e. the user did not pin them via env or YAML)
+//
+// Returns true if any field was changed.
+func ApplyDingoGenesisOverride(shelleyStart, epochLenSlots uint64) bool {
+	// Require both Dingo genesis metrics before touching slot math config.
+	if shelleyStart == 0 || epochLenSlots == 0 {
+		return false
+	}
+	// Nothing to compare against if config has not been loaded yet.
+	if defaultsForCurrentNetwork == nil || globalConfig == nil {
+		return false
+	}
+
+	cfg := globalConfig
+	defaults := defaultsForCurrentNetwork
+	// Only override values that still match the network-table defaults.
+	if cfg.Node.ByronGenesis.StartTime != defaults.Node.ByronGenesis.StartTime ||
+		cfg.Node.ByronGenesis.EpochLength != defaults.Node.ByronGenesis.EpochLength ||
+		cfg.Node.ByronGenesis.SlotLength != defaults.Node.ByronGenesis.SlotLength ||
+		cfg.Node.ShelleyGenesis.EpochLength != defaults.Node.ShelleyGenesis.EpochLength ||
+		cfg.Node.ShelleyGenesis.SlotLength != defaults.Node.ShelleyGenesis.SlotLength {
+		return false
+	}
+
+	changed := cfg.Node.ByronGenesis.StartTime != shelleyStart ||
+		cfg.Node.ShelleyGenesis.EpochLength != epochLenSlots ||
+		cfg.Node.ShelleyTransEpoch != 0
+
+	cfg.Node.ByronGenesis.StartTime = shelleyStart
+	cfg.Node.ShelleyGenesis.EpochLength = epochLenSlots
+	cfg.Node.ShelleyTransEpoch = 0
+	return changed
 }
 
 // Populates NetworkMagic from named networks
@@ -222,73 +292,85 @@ func (c *Config) populateShelleyTransEpoch() error {
 
 // Populates ByronGenesisConfig from named networks
 func (c *Config) populateByronGenesis() error {
-	if c.Node.ByronGenesis.StartTime != 0 {
-		return nil
-	}
 	// Our slot length is always 20000 in supported networks
-	c.Node.ByronGenesis.SlotLength = 20000
+	if c.Node.ByronGenesis.SlotLength == 0 {
+		c.Node.ByronGenesis.SlotLength = 20000
+	}
 	// Our K is 2160, except preview, which we'll override below
-	c.Node.ByronGenesis.K = 2160
+	if c.Node.ByronGenesis.K == 0 {
+		c.Node.ByronGenesis.K = 2160
+	}
+
+	network := c.Node.Network
 	if c.App.Network != "" {
-		switch c.App.Network {
-		case "preview":
-			c.Node.ByronGenesis.K = 432
-			c.Node.ByronGenesis.StartTime = 1666656000
-		case "preprod":
-			c.Node.ByronGenesis.StartTime = 1654041600
-		case "sancho":
-			c.Node.ByronGenesis.K = 432
-			c.Node.ByronGenesis.StartTime = 1686789000
-		case "mainnet":
-			c.Node.ByronGenesis.StartTime = 1506203091
-		}
-	} else if c.Node.Network != "" {
-		switch c.Node.Network {
-		case "preview":
-			c.Node.ByronGenesis.K = 432
-			c.Node.ByronGenesis.StartTime = 1666656000
-		case "preprod":
-			c.Node.ByronGenesis.StartTime = 1654041600
-		case "sancho":
-			c.Node.ByronGenesis.K = 432
-			c.Node.ByronGenesis.StartTime = 1686789000
-		case "mainnet":
-			c.Node.ByronGenesis.StartTime = 1506203091
-		}
-	} else {
+		network = c.App.Network
+	}
+	if network == "" {
 		return errors.New("unable to populate byron genesis config")
 	}
-	c.Node.ByronGenesis.EpochLength = (10 * c.Node.ByronGenesis.K)
+
+	switch network {
+	case "preview":
+		if c.Node.ByronGenesis.K == 2160 {
+			c.Node.ByronGenesis.K = 432
+		}
+		if c.Node.ByronGenesis.StartTime == 0 {
+			c.Node.ByronGenesis.StartTime = 1666656000
+		}
+	case "preprod":
+		if c.Node.ByronGenesis.StartTime == 0 {
+			c.Node.ByronGenesis.StartTime = 1654041600
+		}
+	case "sancho":
+		if c.Node.ByronGenesis.K == 2160 {
+			c.Node.ByronGenesis.K = 432
+		}
+		if c.Node.ByronGenesis.StartTime == 0 {
+			c.Node.ByronGenesis.StartTime = 1686789000
+		}
+	case "mainnet":
+		if c.Node.ByronGenesis.StartTime == 0 {
+			c.Node.ByronGenesis.StartTime = 1506203091
+		}
+	}
+	if c.Node.ByronGenesis.EpochLength == 0 {
+		c.Node.ByronGenesis.EpochLength = (10 * c.Node.ByronGenesis.K)
+		return nil
+	}
+	if c.Node.ByronGenesis.StartTime == 0 {
+		return nil
+	}
 	return nil
 }
 
 // Populates ShelleyGenesisConfig from named networks
 func (c *Config) populateShelleyGenesis() error {
-	if c.Node.ShelleyGenesis.EpochLength != 0 {
-		return nil
-	}
 	// Our slot length is always 1000 in supported networks
-	c.Node.ShelleyGenesis.SlotLength = 1000
+	if c.Node.ShelleyGenesis.SlotLength == 0 {
+		c.Node.ShelleyGenesis.SlotLength = 1000
+	}
 	// Our slots per KES period is always 129600 in supported networks
-	c.Node.ShelleyGenesis.SlotsPerKESPeriod = 129600
-	// Our epoch length is 432000, except sanchonet/preview
-	c.Node.ShelleyGenesis.EpochLength = 432000
+	if c.Node.ShelleyGenesis.SlotsPerKESPeriod == 0 {
+		c.Node.ShelleyGenesis.SlotsPerKESPeriod = 129600
+	}
+
+	network := c.Node.Network
 	if c.App.Network != "" {
-		switch c.App.Network {
-		case "sancho":
-			c.Node.ShelleyGenesis.EpochLength = 86400
-		case "preview":
-			c.Node.ShelleyGenesis.EpochLength = 86400
-		}
-	} else if c.Node.Network != "" {
-		switch c.Node.Network {
-		case "sancho":
-			c.Node.ShelleyGenesis.EpochLength = 86400
-		case "preview":
+		network = c.App.Network
+	}
+	if network == "" {
+		return errors.New("unable to populate shelley genesis config")
+	}
+
+	if c.Node.ShelleyGenesis.EpochLength == 0 {
+		// Our epoch length is 432000, except sanchonet/preview
+		c.Node.ShelleyGenesis.EpochLength = 432000
+		switch network {
+		case "sancho", "preview":
 			c.Node.ShelleyGenesis.EpochLength = 86400
 		}
 	} else {
-		return errors.New("unable to populate shelley genesis config")
+		return nil
 	}
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -103,8 +103,10 @@ func getDefaultConfig() *Config {
 }
 
 // Singleton config instance with default values
-var globalConfig = getDefaultConfig()
-var defaultsForCurrentNetwork = getDefaultConfig()
+var (
+	globalConfig              = getDefaultConfig()
+	defaultsForCurrentNetwork = getDefaultConfig()
+)
 
 // LoadConfig loads configuration from a YAML file and environment variables.
 // Environment variables take precedence over file values. If configFile is empty,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -257,18 +257,18 @@ func TestApplyDingoGenesisOverride(t *testing.T) {
 		t.Fatalf("Failed to load config: %v", err)
 	}
 
-	if !ApplyDingoGenesisOverride(1700000000, 1000) {
+	if !ApplyDingoGenesisOverride(1666656000, 86400) {
 		t.Fatal("Expected Dingo genesis override to apply")
 	}
-	if cfg.Node.ByronGenesis.StartTime != 1700000000 {
+	if cfg.Node.ByronGenesis.StartTime != 1666656000 {
 		t.Errorf(
-			"Expected Byron start time 1700000000, got %d",
+			"Expected Byron start time 1666656000, got %d",
 			cfg.Node.ByronGenesis.StartTime,
 		)
 	}
-	if cfg.Node.ShelleyGenesis.EpochLength != 1000 {
+	if cfg.Node.ShelleyGenesis.EpochLength != 86400 {
 		t.Errorf(
-			"Expected Shelley epoch length 1000, got %d",
+			"Expected Shelley epoch length 86400, got %d",
 			cfg.Node.ShelleyGenesis.EpochLength,
 		)
 	}
@@ -278,7 +278,7 @@ func TestApplyDingoGenesisOverride(t *testing.T) {
 			cfg.Node.ShelleyTransEpoch,
 		)
 	}
-	if ApplyDingoGenesisOverride(1700000000, 1000) {
+	if ApplyDingoGenesisOverride(1666656000, 86400) {
 		t.Fatal("Expected second Dingo genesis override to be skipped")
 	}
 }
@@ -290,8 +290,8 @@ func TestApplyDingoGenesisOverrideZeroMetrics(t *testing.T) {
 		shelleyStart  uint64
 		epochLenSlots uint64
 	}{
-		{"zero Shelley start", 0, 1000},
-		{"zero epoch length", 1700000000, 0},
+		{"zero Shelley start", 0, 86400},
+		{"zero epoch length", 1666656000, 0},
 	}
 
 	for _, tt := range tests {
@@ -357,7 +357,7 @@ func TestApplyDingoGenesisOverrideSkipsPinnedGenesisValues(t *testing.T) {
 			shelleySlotLen := cfg.Node.ShelleyGenesis.SlotLength
 			transEpoch := cfg.Node.ShelleyTransEpoch
 
-			if ApplyDingoGenesisOverride(1700000000, 1000) {
+			if ApplyDingoGenesisOverride(1666656000, 86400) {
 				t.Fatal("Expected Dingo genesis override to be skipped")
 			}
 			if cfg.Node.ByronGenesis.StartTime != start ||

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,22 +5,29 @@ import (
 	"testing"
 )
 
-func TestLoadConfig(t *testing.T) {
-	// Clear any dummy env vars that might affect the test
+func resetConfigEnv(t *testing.T) {
+	t.Helper()
 	envVars := []string{
+		"BYRON_GENESIS_START_SEC", "BYRON_EPOCH_LENGTH", "BYRON_SLOT_LENGTH",
+		"SHELLEY_EPOCH_LENGTH", "SHELLEY_SLOT_LENGTH",
 		"DUMMY_NODE_NAME", "DUMMY_NETWORK", "DUMMY_REFRESH", "DUMMY_RETRIES",
 		"DUMMY_CARDANO_NODE_BINARY", "DUMMY_CARDANO_NODE_PID_FILE", "DUMMY_CARDANO_NETWORK",
 		"DUMMY_CARDANO_NODE_NETWORK_MAGIC", "DUMMY_CARDANO_PORT", "DUMMY_SHELLEY_TRANS_EPOCH",
 		"DUMMY_CARDANO_BLOCK_PRODUCER", "DUMMY_PROM_HOST", "DUMMY_PROM_PORT",
 		"DUMMY_PROM_REFRESH", "DUMMY_PROM_TIMEOUT", "DUMMY_BYRON_GENESIS_START_SEC",
 		"DUMMY_BYRON_EPOCH_LENGTH", "DUMMY_BYRON_K", "DUMMY_BYRON_SLOT_LENGTH",
-		"DUMMY_SHELLEY_EPOCH_LENGTH",
+		"DUMMY_SHELLEY_EPOCH_LENGTH", "DUMMY_SHELLEY_SLOT_LENGTH",
 	}
 	for _, v := range envVars {
 		os.Unsetenv(v)
 	}
 	// Reset globalConfig to defaults
 	globalConfig = getDefaultConfig()
+	defaultsForCurrentNetwork = getDefaultConfig()
+}
+
+func TestLoadConfig(t *testing.T) {
+	resetConfigEnv(t)
 
 	// Test loading default config
 	cfg, err := LoadConfig("")
@@ -205,6 +212,8 @@ func TestPopulateShelleyTransEpoch(t *testing.T) {
 }
 
 func TestLoadConfigWithNetwork(t *testing.T) {
+	resetConfigEnv(t)
+
 	// Create a temporary config file
 	configContent := `
 app:
@@ -236,5 +245,129 @@ node:
 			"Expected NetworkMagic 1 for preprod, got %d",
 			cfg.Node.NetworkMagic,
 		)
+	}
+}
+
+// Verifies Dingo metrics override hardcoded defaults once when both metrics exist.
+func TestApplyDingoGenesisOverride(t *testing.T) {
+	resetConfigEnv(t)
+
+	cfg, err := LoadConfig("")
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	if !ApplyDingoGenesisOverride(1700000000, 1000) {
+		t.Fatal("Expected Dingo genesis override to apply")
+	}
+	if cfg.Node.ByronGenesis.StartTime != 1700000000 {
+		t.Errorf(
+			"Expected Byron start time 1700000000, got %d",
+			cfg.Node.ByronGenesis.StartTime,
+		)
+	}
+	if cfg.Node.ShelleyGenesis.EpochLength != 1000 {
+		t.Errorf(
+			"Expected Shelley epoch length 1000, got %d",
+			cfg.Node.ShelleyGenesis.EpochLength,
+		)
+	}
+	if cfg.Node.ShelleyTransEpoch != 0 {
+		t.Errorf(
+			"Expected Shelley transition epoch 0, got %d",
+			cfg.Node.ShelleyTransEpoch,
+		)
+	}
+	if ApplyDingoGenesisOverride(1700000000, 1000) {
+		t.Fatal("Expected second Dingo genesis override to be skipped")
+	}
+}
+
+// Verifies missing Dingo genesis metrics leave config unchanged.
+func TestApplyDingoGenesisOverrideZeroMetrics(t *testing.T) {
+	tests := []struct {
+		name          string
+		shelleyStart  uint64
+		epochLenSlots uint64
+	}{
+		{"zero Shelley start", 0, 1000},
+		{"zero epoch length", 1700000000, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetConfigEnv(t)
+
+			cfg, err := LoadConfig("")
+			if err != nil {
+				t.Fatalf("Failed to load config: %v", err)
+			}
+			start := cfg.Node.ByronGenesis.StartTime
+			epochLen := cfg.Node.ShelleyGenesis.EpochLength
+
+			if ApplyDingoGenesisOverride(tt.shelleyStart, tt.epochLenSlots) {
+				t.Fatal("Expected Dingo genesis override to be skipped")
+			}
+			if cfg.Node.ByronGenesis.StartTime != start {
+				t.Errorf(
+					"Expected Byron start time %d, got %d",
+					start,
+					cfg.Node.ByronGenesis.StartTime,
+				)
+			}
+			if cfg.Node.ShelleyGenesis.EpochLength != epochLen {
+				t.Errorf(
+					"Expected Shelley epoch length %d, got %d",
+					epochLen,
+					cfg.Node.ShelleyGenesis.EpochLength,
+				)
+			}
+		})
+	}
+}
+
+// Verifies explicit user genesis config takes priority over Dingo metrics.
+func TestApplyDingoGenesisOverrideSkipsPinnedGenesisValues(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		val  string
+	}{
+		{"Byron start pinned", "BYRON_GENESIS_START_SEC", "1700000001"},
+		{"Byron epoch length pinned", "BYRON_EPOCH_LENGTH", "999"},
+		{"Byron slot length pinned", "BYRON_SLOT_LENGTH", "999"},
+		{"Shelley epoch length pinned", "SHELLEY_EPOCH_LENGTH", "999"},
+		{"Shelley slot length pinned", "SHELLEY_SLOT_LENGTH", "2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetConfigEnv(t)
+			os.Setenv(tt.env, tt.val)
+			defer os.Unsetenv(tt.env)
+
+			cfg, err := LoadConfig("")
+			if err != nil {
+				t.Fatalf("Failed to load config: %v", err)
+			}
+			start := cfg.Node.ByronGenesis.StartTime
+			byronEpochLen := cfg.Node.ByronGenesis.EpochLength
+			byronSlotLen := cfg.Node.ByronGenesis.SlotLength
+			shelleyEpochLen := cfg.Node.ShelleyGenesis.EpochLength
+			shelleySlotLen := cfg.Node.ShelleyGenesis.SlotLength
+			transEpoch := cfg.Node.ShelleyTransEpoch
+
+			if ApplyDingoGenesisOverride(1700000000, 1000) {
+				t.Fatal("Expected Dingo genesis override to be skipped")
+			}
+			if cfg.Node.ByronGenesis.StartTime != start ||
+				cfg.Node.ByronGenesis.EpochLength != byronEpochLen ||
+				cfg.Node.ByronGenesis.SlotLength != byronSlotLen ||
+				cfg.Node.ShelleyGenesis.EpochLength != shelleyEpochLen ||
+				cfg.Node.ShelleyGenesis.SlotLength != shelleySlotLen ||
+				cfg.Node.ShelleyTransEpoch != transEpoch {
+				t.Fatal("Expected pinned config to remain unchanged")
+			}
+		})
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,7 +9,7 @@ func resetConfigEnv(t *testing.T) {
 	t.Helper()
 	envVars := []string{
 		"BYRON_GENESIS_START_SEC", "BYRON_EPOCH_LENGTH", "BYRON_SLOT_LENGTH",
-		"SHELLEY_EPOCH_LENGTH", "SHELLEY_SLOT_LENGTH",
+		"SHELLEY_EPOCH_LENGTH", "SHELLEY_SLOT_LENGTH", "SHELLEY_TRANS_EPOCH",
 		"DUMMY_NODE_NAME", "DUMMY_NETWORK", "DUMMY_REFRESH", "DUMMY_RETRIES",
 		"DUMMY_CARDANO_NODE_BINARY", "DUMMY_CARDANO_NODE_PID_FILE", "DUMMY_CARDANO_NETWORK",
 		"DUMMY_CARDANO_NODE_NETWORK_MAGIC", "DUMMY_CARDANO_PORT", "DUMMY_SHELLEY_TRANS_EPOCH",
@@ -22,8 +22,8 @@ func resetConfigEnv(t *testing.T) {
 		os.Unsetenv(v)
 	}
 	// Reset globalConfig to defaults
-	globalConfig = getDefaultConfig()
-	defaultsForCurrentNetwork = getDefaultConfig()
+	globalConfig.Store(getDefaultConfig())
+	defaultsForCurrentNetwork.Store(nil)
 }
 
 func TestLoadConfig(t *testing.T) {
@@ -130,6 +130,33 @@ func TestPopulateByronGenesis(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+func TestPopulateByronGenesisPreservesPinnedK(t *testing.T) {
+	cfg := &Config{
+		App: AppConfig{
+			Network: "preview",
+		},
+		Node: NodeConfig{
+			ByronGenesis: ByronGenesisConfig{
+				K: 2160,
+			},
+		},
+	}
+
+	err := cfg.populateByronGenesis()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if cfg.Node.ByronGenesis.K != 2160 {
+		t.Errorf("Expected pinned K 2160, got %d", cfg.Node.ByronGenesis.K)
+	}
+	if cfg.Node.ByronGenesis.EpochLength != 21600 {
+		t.Errorf(
+			"Expected EpochLength 21600 from pinned K, got %d",
+			cfg.Node.ByronGenesis.EpochLength,
+		)
 	}
 }
 
@@ -252,7 +279,7 @@ node:
 func TestApplyDingoGenesisOverride(t *testing.T) {
 	resetConfigEnv(t)
 
-	cfg, err := LoadConfig("")
+	_, err := LoadConfig("")
 	if err != nil {
 		t.Fatalf("Failed to load config: %v", err)
 	}
@@ -260,6 +287,7 @@ func TestApplyDingoGenesisOverride(t *testing.T) {
 	if !ApplyDingoGenesisOverride(1666656000, 86400) {
 		t.Fatal("Expected Dingo genesis override to apply")
 	}
+	cfg := GetConfig()
 	if cfg.Node.ByronGenesis.StartTime != 1666656000 {
 		t.Errorf(
 			"Expected Byron start time 1666656000, got %d",
@@ -338,6 +366,7 @@ func TestApplyDingoGenesisOverrideSkipsPinnedGenesisValues(t *testing.T) {
 		{"Byron slot length pinned", "BYRON_SLOT_LENGTH", "999"},
 		{"Shelley epoch length pinned", "SHELLEY_EPOCH_LENGTH", "999"},
 		{"Shelley slot length pinned", "SHELLEY_SLOT_LENGTH", "2"},
+		{"Shelley transition epoch pinned", "SHELLEY_TRANS_EPOCH", "1"},
 	}
 
 	for _, tt := range tests {

--- a/main.go
+++ b/main.go
@@ -278,6 +278,20 @@ func main() {
 				}
 				continue
 			}
+			if getEffectiveNodeBinary() == DINGO_BINARY && prom != nil {
+				if config.ApplyDingoGenesisOverride(
+					prom.DingoShelleyStartTime,
+					prom.DingoEpochLengthSlots,
+				) {
+					logger.Info(
+						"genesis params overridden from Dingo metrics",
+						"shelleyStart",
+						prom.DingoShelleyStartTime,
+						"epochLengthSlots",
+						prom.DingoEpochLengthSlots,
+					)
+				}
+			}
 			promMetrics = prom
 			select {
 			case <-ctx.Done():

--- a/prometheus.go
+++ b/prometheus.go
@@ -82,11 +82,13 @@ type PromMetrics struct {
 	ConnFullDuplex      uint64  `json:"cardano_node_metrics_connectionManager_fullDuplexConns"`
 	ConnPrunable        uint64  `json:"cardano_node_metrics_connectionManager_prunableConns"`
 	// Go runtime metrics for Dingo
-	GoMemAlloc  uint64 `json:"go_memstats_alloc_bytes"`
-	GoHeapIdle  uint64 `json:"go_memstats_heap_idle_bytes"`
-	GoHeapInuse uint64 `json:"go_memstats_heap_inuse_bytes"`
-	GoHeapSys   uint64 `json:"go_memstats_heap_sys_bytes"`
-	GoGcCount   uint64 `json:"go_gc_duration_seconds_count"`
+	GoMemAlloc            uint64 `json:"go_memstats_alloc_bytes"`
+	GoHeapIdle            uint64 `json:"go_memstats_heap_idle_bytes"`
+	GoHeapInuse           uint64 `json:"go_memstats_heap_inuse_bytes"`
+	GoHeapSys             uint64 `json:"go_memstats_heap_sys_bytes"`
+	GoGcCount             uint64 `json:"go_gc_duration_seconds_count"`
+	DingoShelleyStartTime uint64 `json:"dingo_shelley_start_time"`
+	DingoEpochLengthSlots uint64 `json:"dingo_epoch_length_slots"`
 }
 
 // Gets metrics from prometheus and return a PromMetrics instance

--- a/prometheus_test.go
+++ b/prometheus_test.go
@@ -199,6 +199,28 @@ cardano_node_metrics_connectionManager_prunableConns 2
 	}
 }
 
+func TestPromMetricsDingoGenesisFields(t *testing.T) {
+	prom := []byte(`
+dingo_shelley_start_time 1700000000
+dingo_epoch_length_slots 1000
+`)
+
+	metrics := decodePromMetrics(t, prom)
+
+	if metrics.DingoShelleyStartTime != 1700000000 {
+		t.Errorf(
+			"DingoShelleyStartTime = %d, expected 1700000000",
+			metrics.DingoShelleyStartTime,
+		)
+	}
+	if metrics.DingoEpochLengthSlots != 1000 {
+		t.Errorf(
+			"DingoEpochLengthSlots = %d, expected 1000",
+			metrics.DingoEpochLengthSlots,
+		)
+	}
+}
+
 func decodePromMetrics(t *testing.T, prom []byte) PromMetrics {
 	t.Helper()
 


### PR DESCRIPTION
1. Added parsing for Dingo genesis metrics dingo_shelley_start_time and dingo_epoch_length_slots.
2. Added ApplyDingoGenesisOverride in config to update slot config from dingo metrics where we preserved user-pinned Byron/Shelley genesis values during config population. Mapped dingo shelley start time to ByronGenesis.StartTime and dingo epoch length to ShelleyGenesis.EpochLength.
3. Added a current-network defaults snapshot to detect user-pinned genesis config.
4. Called the override after successful Dingo Prometheus scrapes and added a log statement once when dingo genesis params override hardcoded defaults.
5. Added tests for successful override, zero metrics, pinned config, and metric parsing.

Closes #448 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives Shelley genesis from Dingo Prometheus metrics and applies overrides only when config still matches per-network defaults. Makes the override thread-safe and fixes slot math on Dingo devnets without a Byron era. Implements #448.

- New Features
  - Parse `dingo_shelley_start_time` and `dingo_epoch_length_slots` in `PromMetrics`.
  - Add `ApplyDingoGenesisOverride(...)`: when both metrics exist and values still match network defaults, set `ByronGenesis.StartTime`, `ShelleyGenesis.EpochLength`, and `ShelleyTransEpoch=0`; run after a `dingo` scrape and log on change.
  - Snapshot per-network defaults at load to detect pinned values and avoid overriding user config.

- Refactors
  - Use `atomic.Pointer` for the global config and defaults snapshot to prevent races during overrides.
  - Make `populateByronGenesis`/`populateShelleyGenesis` fill only missing fields and respect pinned values (including `K`).
  - Add tests for override success, zero metrics, pinned config (incl. pinned `K`), and metric parsing.

<sup>Written for commit cbd4cb522da22354cba2f5fb461865f9ce412493. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic override of genesis timing from Dingo node metrics when available.

* **Improvements**
  * Configuration now maintains network-specific defaults to better distinguish user changes from computed defaults.
  * Genesis updates are more selective, preserving pinned/user-provided values while permitting metric-driven adjustments.

* **Tests**
  * Added unit tests covering Dingo metrics parsing and genesis-override behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/nview/pull/452)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->