### PR TITLE
feat(prometheus): Add Diagnostics view (default secondary view; gates peer scans)

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log/slog"
 	"math"
 	"net"
@@ -332,7 +333,7 @@ func main() {
 
 	// Initialize logger with buffer
 	baseHandler := slog.NewTextHandler(
-		os.Stderr,
+		io.Discard,
 		&slog.HandlerOptions{Level: slog.LevelInfo},
 	)
 	bufferedHandler := &bufferHandler{handler: baseHandler}

--- a/main.go
+++ b/main.go
@@ -516,17 +516,7 @@ func main() {
 				return
 			default:
 			}
-			err := pingPeers(ctx)
-			if err != nil {
-				logger.Warn("Failed to ping peers", "error", err)
-				failCount.Add(1)
-				select {
-				case <-ctx.Done():
-					return
-				case <-time.After(time.Second * 10):
-				}
-				continue
-			}
+			pingPeers(ctx)
 			select {
 			case <-ctx.Done():
 				return

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	"math"
 	"net"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -881,37 +882,41 @@ func getDingoStats() string {
 	}
 	prev := lastDingoRateBase
 	prevAt := lastDingoRateBaseAt
+	currAt := lastDingoSampleAt
 	lastDingoSampleMu.Unlock()
 
 	prevMetrics := &PromMetrics{}
 	dt := time.Duration(0)
 	if prev != nil {
 		prevMetrics = prev
-		dt = now.Sub(prevAt)
+		dt = currAt.Sub(prevAt)
 	}
 
-	utxoRatio := formatDingoHitRatio(
-		curr.DingoCacheUtxoHotHits,
-		curr.DingoCacheUtxoHotMiss,
-		prevMetrics.DingoCacheUtxoHotHits,
-		prevMetrics.DingoCacheUtxoHotMiss,
-	)
-	txRatio := formatDingoHitRatio(
-		curr.DingoCacheTxHotHits,
-		curr.DingoCacheTxHotMiss,
-		prevMetrics.DingoCacheTxHotHits,
-		prevMetrics.DingoCacheTxHotMiss,
-	)
-	blockRatio := formatDingoHitRatio(
-		curr.DingoCacheBlockLruHits,
-		curr.DingoCacheBlockLruMiss,
-		prevMetrics.DingoCacheBlockLruHits,
-		prevMetrics.DingoCacheBlockLruMiss,
-	)
+	utxoRatio := "n/a"
+	txRatio := "n/a"
+	blockRatio := "n/a"
 	coldExtractRate := "n/a"
 	eventErrorRate := "n/a"
 	eventTimeoutRate := "n/a"
 	if prev != nil {
+		utxoRatio = formatDingoHitRatio(
+			curr.DingoCacheUtxoHotHits,
+			curr.DingoCacheUtxoHotMiss,
+			prevMetrics.DingoCacheUtxoHotHits,
+			prevMetrics.DingoCacheUtxoHotMiss,
+		)
+		txRatio = formatDingoHitRatio(
+			curr.DingoCacheTxHotHits,
+			curr.DingoCacheTxHotMiss,
+			prevMetrics.DingoCacheTxHotHits,
+			prevMetrics.DingoCacheTxHotMiss,
+		)
+		blockRatio = formatDingoHitRatio(
+			curr.DingoCacheBlockLruHits,
+			curr.DingoCacheBlockLruMiss,
+			prevMetrics.DingoCacheBlockLruHits,
+			prevMetrics.DingoCacheBlockLruMiss,
+		)
 		coldExtractRate = formatDingoRate(
 			curr.DingoCacheColdExtract,
 			prevMetrics.DingoCacheColdExtract,
@@ -1347,11 +1352,30 @@ func getPeerText(ctx context.Context) string {
 	charUnmarked = string('▖')
 	granularity := ProgressBarGranularity
 	granularitySmall := granularity / 2
+
+	peersFilteredMu.RLock()
 	peerCount := len(peersFiltered)
-	if peerCount == 0 || len(peerStats.RTTresultsSlice) < peerCount {
+	peersFilteredMu.RUnlock()
+
+	peerStatsMu.Lock()
+	rttCount := len(peerStats.RTTresultsSlice)
+	cnt0 := peerStats.CNT0
+	cnt1 := peerStats.CNT1
+	cnt2 := peerStats.CNT2
+	cnt3 := peerStats.CNT3
+	cnt4 := peerStats.CNT4
+	pct1 := peerStats.PCT1
+	pct2 := peerStats.PCT2
+	pct3 := peerStats.PCT3
+	pct4 := peerStats.PCT4
+	rttAvg := peerStats.RTTAVG
+	peers := slices.Clone(peerStats.RTTresultsSlice)
+	peerStatsMu.Unlock()
+
+	if peerCount == 0 || rttCount < peerCount {
 		fmt.Fprintf(&sb, " [yellow]%s [blue]%d[white]/[green]%d[white]\n",
 			"Peer analysis started... please wait!",
-			len(peerStats.RTTresultsSlice),
+			rttCount,
 			peerCount)
 		scrollPeers = false
 		return sb.String()
@@ -1359,12 +1383,12 @@ func getPeerText(ctx context.Context) string {
 
 	sb.WriteString("       [green]RTT : Peers / Percent\n")
 	fmt.Fprintf(&sb, "    [green]0-50ms : [white]%5s   %.f%%",
-		strconv.Itoa(peerStats.CNT1),
-		peerStats.PCT1)
-	fmt.Fprintf(&sb, "%"+strconv.Itoa(10-len(fmt.Sprintf("%.f", peerStats.PCT1)))+"s",
+		strconv.Itoa(cnt1),
+		pct1)
+	fmt.Fprintf(&sb, "%"+strconv.Itoa(10-len(fmt.Sprintf("%.f", pct1)))+"s",
 		" ")
 	for i := range granularitySmall {
-		if i < int(peerStats.PCT1) {
+		if i < int(pct1) {
 			sb.WriteString("[green]" + charMarked)
 		} else {
 			sb.WriteString("[white]" + charUnmarked)
@@ -1372,12 +1396,12 @@ func getPeerText(ctx context.Context) string {
 	}
 	sb.WriteString("[white]\n") // closeRow
 	fmt.Fprintf(&sb, "  [green]50-100ms : [white]%5s   %.f%%",
-		strconv.Itoa(peerStats.CNT2),
-		peerStats.PCT2)
-	fmt.Fprintf(&sb, "%"+strconv.Itoa(10-len(fmt.Sprintf("%.f", peerStats.PCT2)))+"s",
+		strconv.Itoa(cnt2),
+		pct2)
+	fmt.Fprintf(&sb, "%"+strconv.Itoa(10-len(fmt.Sprintf("%.f", pct2)))+"s",
 		"")
 	for i := range granularitySmall {
-		if i < int(peerStats.PCT2) {
+		if i < int(pct2) {
 			sb.WriteString("[yellow]" + charMarked)
 		} else {
 			sb.WriteString("[white]" + charUnmarked)
@@ -1385,12 +1409,12 @@ func getPeerText(ctx context.Context) string {
 	}
 	sb.WriteString("[white]\n") // closeRow
 	fmt.Fprintf(&sb, " [green]100-200ms : [white]%5s   %.f%%",
-		strconv.Itoa(peerStats.CNT3),
-		peerStats.PCT3)
-	fmt.Fprintf(&sb, "%"+strconv.Itoa(10-len(fmt.Sprintf("%.f", peerStats.PCT3)))+"s",
+		strconv.Itoa(cnt3),
+		pct3)
+	fmt.Fprintf(&sb, "%"+strconv.Itoa(10-len(fmt.Sprintf("%.f", pct3)))+"s",
 		"")
 	for i := range granularitySmall {
-		if i < int(peerStats.PCT3) {
+		if i < int(pct3) {
 			sb.WriteString("[red]" + charMarked)
 		} else {
 			sb.WriteString("[white]" + charUnmarked)
@@ -1398,12 +1422,12 @@ func getPeerText(ctx context.Context) string {
 	}
 	sb.WriteString("[white]\n") // closeRow
 	fmt.Fprintf(&sb, "   [green]200ms < : [white]%5s   %.f%%",
-		strconv.Itoa(peerStats.CNT4),
-		peerStats.PCT4)
-	fmt.Fprintf(&sb, "%"+strconv.Itoa(10-len(fmt.Sprintf("%.f", peerStats.PCT4)))+"s",
+		strconv.Itoa(cnt4),
+		pct4)
+	fmt.Fprintf(&sb, "%"+strconv.Itoa(10-len(fmt.Sprintf("%.f", pct4)))+"s",
 		"")
 	for i := range granularitySmall {
-		if i < int(peerStats.PCT4) {
+		if i < int(pct4) {
 			sb.WriteString("[fuchsia]" + charMarked)
 		} else {
 			sb.WriteString("[white]" + charUnmarked)
@@ -1416,20 +1440,20 @@ func getPeerText(ctx context.Context) string {
 
 	fmt.Fprintf(&sb, " [green]Total / Undetermined : [white]%d[white] / ",
 		peerCount)
-	if peerStats.CNT0 == 0 {
+	if cnt0 == 0 {
 		sb.WriteString("[blue]0[white]")
 	} else {
-		fmt.Fprintf(&sb, "[fuchsia]%d[white]", peerStats.CNT0)
+		fmt.Fprintf(&sb, "[fuchsia]%d[white]", cnt0)
 	}
-	if peerStats.RTTAVG >= RTTThreshold3 {
+	if rttAvg >= RTTThreshold3 {
 		fmt.Fprintf(&sb, " Average RTT : [fuchsia]%d[white] ms\n",
-			peerStats.RTTAVG)
-	} else if peerStats.RTTAVG >= RTTThreshold2 {
-		fmt.Fprintf(&sb, " Average RTT : [red]%d[white] ms\n", peerStats.RTTAVG)
-	} else if peerStats.RTTAVG >= RTTThreshold1 {
-		fmt.Fprintf(&sb, " Average RTT : [yellow]%d[white] ms\n", peerStats.RTTAVG)
-	} else if peerStats.RTTAVG >= 0 {
-		fmt.Fprintf(&sb, " Average RTT : [green]%d[white] ms\n", peerStats.RTTAVG)
+			rttAvg)
+	} else if rttAvg >= RTTThreshold2 {
+		fmt.Fprintf(&sb, " Average RTT : [red]%d[white] ms\n", rttAvg)
+	} else if rttAvg >= RTTThreshold1 {
+		fmt.Fprintf(&sb, " Average RTT : [yellow]%d[white] ms\n", rttAvg)
+	} else if rttAvg >= 0 {
+		fmt.Fprintf(&sb, " Average RTT : [green]%d[white] ms\n", rttAvg)
 	} else {
 		fmt.Fprintf(&sb, " Average RTT : [red]%s[white] ms\n", "---")
 	}
@@ -1439,7 +1463,7 @@ func getPeerText(ctx context.Context) string {
 
 	fmt.Fprintf(&sb, "   [green]# %24s  I/O RTT   Geolocation\n", "REMOTE PEER")
 	// peerLocationWidth := width - 41
-	for peerNbr, peer := range peerStats.RTTresultsSlice {
+	for peerNbr, peer := range peers {
 		peerNbr++
 		peerRTT := peer.RTT
 		peerPORT := peer.Port

--- a/main.go
+++ b/main.go
@@ -136,6 +136,12 @@ const (
 	viewDingo
 )
 
+const (
+	viewNoneValue  int32 = int32(viewNone)
+	viewPeersValue int32 = int32(viewPeers)
+	viewDingoValue int32 = int32(viewDingo)
+)
+
 var (
 	activeSecondary     atomic.Int32
 	secondaryDefaultSet atomic.Bool
@@ -229,7 +235,14 @@ func getActiveSecondaryView() secondaryView {
 }
 
 func setActiveSecondaryView(view secondaryView) {
-	activeSecondary.Store(int32(view))
+	switch view {
+	case viewNone:
+		activeSecondary.Store(viewNoneValue)
+	case viewPeers:
+		activeSecondary.Store(viewPeersValue)
+	case viewDingo:
+		activeSecondary.Store(viewDingoValue)
+	}
 }
 
 func applyDefaultSecondaryView() {
@@ -279,6 +292,8 @@ func getSecondaryViewText(ctx context.Context) (string, string) {
 		return "Peers", getPeerText(ctx)
 	case viewDingo:
 		return "Dingo Diagnostics", getDingoStats()
+	case viewNone:
+		return "Secondary", ""
 	default:
 		return "Secondary", ""
 	}

--- a/main.go
+++ b/main.go
@@ -128,6 +128,25 @@ var (
 	dingoProcessAmbiguityLogged atomic.Bool
 )
 
+type secondaryView int
+
+const (
+	viewNone secondaryView = iota
+	viewPeers
+	viewDingo
+)
+
+var (
+	activeSecondary     atomic.Int32
+	secondaryDefaultSet atomic.Bool
+	lastDingoSample     *PromMetrics
+	lastDingoSampleAt   time.Time
+	lastDingoRateBase   *PromMetrics
+	lastDingoRateBaseAt time.Time
+	lastDingoSampleSrc  *PromMetrics
+	lastDingoSampleMu   sync.Mutex
+)
+
 // Global command line flags
 var cmdlineFlags struct {
 	configFile string
@@ -170,7 +189,8 @@ var coreTextView = tview.NewTextView().
 
 var footerTextView = tview.NewTextView().
 	SetDynamicColors(true).
-	SetTextColor(tcell.ColorGreen)
+	SetTextColor(tcell.ColorGreen).
+	SetWrap(false)
 
 var headerTextView = tview.NewTextView().
 	SetTextColor(tcell.ColorGreen)
@@ -203,6 +223,80 @@ var processMetrics *process.Process
 
 // Track our failures
 var failCount atomic.Uint32
+
+func getActiveSecondaryView() secondaryView {
+	return secondaryView(activeSecondary.Load())
+}
+
+func setActiveSecondaryView(view secondaryView) {
+	activeSecondary.Store(int32(view))
+}
+
+func applyDefaultSecondaryView() {
+	if !secondaryDefaultSet.CompareAndSwap(false, true) {
+		return
+	}
+
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("NVIEW_DEFAULT_VIEW"))) {
+	case "peers":
+		setActiveSecondaryView(viewPeers)
+	case "dingo":
+		if getEffectiveNodeBinary() == DINGO_BINARY {
+			setActiveSecondaryView(viewDingo)
+		} else {
+			setActiveSecondaryView(viewNone)
+			if logger != nil {
+				logger.Debug(
+					"ignoring dingo default view for non-dingo node",
+					"binary",
+					getEffectiveNodeBinary(),
+				)
+			}
+		}
+	case "none":
+		setActiveSecondaryView(viewNone)
+	case "":
+		if getEffectiveNodeBinary() == DINGO_BINARY {
+			setActiveSecondaryView(viewDingo)
+		} else {
+			setActiveSecondaryView(viewNone)
+		}
+	default:
+		setActiveSecondaryView(viewNone)
+		if logger != nil {
+			logger.Debug(
+				"ignoring invalid NVIEW_DEFAULT_VIEW",
+				"value",
+				os.Getenv("NVIEW_DEFAULT_VIEW"),
+			)
+		}
+	}
+}
+
+func getSecondaryViewText(ctx context.Context) (string, string) {
+	switch getActiveSecondaryView() {
+	case viewPeers:
+		return "Peers", getPeerText(ctx)
+	case viewDingo:
+		return "Dingo Diagnostics", getDingoStats()
+	default:
+		return "Secondary", ""
+	}
+}
+
+func updateSecondaryText(ctx context.Context) {
+	title, tmpText := getSecondaryViewText(ctx)
+	peerTextView.SetTitle(title)
+	if tmpText != peerText {
+		peerText = tmpText
+		peerTextView.Clear()
+		peerTextView.SetText(peerText)
+		if scrollPeers {
+			scrollPeers = false
+			peerTextView.ScrollToBeginning()
+		}
+	}
+}
 
 func main() {
 	// Check if any command line flags are given
@@ -250,8 +344,6 @@ func main() {
 	if err == nil {
 		publicIP = &ip
 	}
-	checkPeers = true
-
 	// Fetch data from Prometheus
 	go func() {
 		for {
@@ -296,6 +388,7 @@ func main() {
 					)
 				}
 			}
+			applyDefaultSecondaryView()
 			promMetrics = prom
 			select {
 			case <-ctx.Done():
@@ -448,11 +541,12 @@ func main() {
 		SetTitle("Block Propagation").
 		SetBorder(true)
 
-	peerText = getPeerText(ctx)
-	peerTextView.SetText(peerText).SetTitle("Peers").SetBorder(true)
+	peerTitle, peerTextValue := getSecondaryViewText(ctx)
+	peerText = peerTextValue
+	peerTextView.SetText(peerText).SetTitle(peerTitle).SetBorder(true)
 
 	// Set our footer
-	defaultFooterText := " [yellow](esc/q)[white] Quit | [yellow](p)[white] Peer Analysis"
+	defaultFooterText := " [yellow](esc/q)[white] Quit | [yellow](p)[white] Peers | [yellow](d)[white] Dingo"
 	footerTextView.SetText(defaultFooterText)
 
 	// Add content to our flex box
@@ -528,7 +622,6 @@ func main() {
 		if event.Rune() == 104 || event.Rune() == 114 { // h or r
 			setRole()
 			resetPeers()
-			checkPeers = true
 			footerTextView.Clear()
 			footerTextView.SetText(defaultFooterText)
 			var tmpText string
@@ -572,23 +665,33 @@ func main() {
 				blockTextView.Clear()
 				blockTextView.SetText(blockText)
 			}
-			// Peers are last since they take time to process
-			tmpText = getPeerText(ctx)
-			if tmpText != "" && tmpText != peerText {
-				peerText = tmpText
-				peerTextView.Clear()
-				peerTextView.SetText(peerText)
-				// Scroll to the top only once
-				if scrollPeers {
-					scrollPeers = false
-					peerTextView.ScrollToBeginning()
-				}
-			}
+			updateSecondaryText(ctx)
 		}
 		if event.Rune() == 112 { // p
 			resetPeers()
-			checkPeers = true
+			if getActiveSecondaryView() == viewPeers {
+				setActiveSecondaryView(viewNone)
+			} else {
+				setActiveSecondaryView(viewPeers)
+			}
 			scrollPeers = false
+			updateSecondaryText(ctx)
+		}
+		if event.Rune() == 100 { // d
+			if getEffectiveNodeBinary() != DINGO_BINARY {
+				if logger != nil {
+					logger.Debug(
+						"ignoring dingo diagnostics keypress for non-dingo node",
+						"binary",
+						getEffectiveNodeBinary(),
+					)
+				}
+			} else if getActiveSecondaryView() == viewDingo {
+				setActiveSecondaryView(viewNone)
+			} else {
+				setActiveSecondaryView(viewDingo)
+			}
+			updateSecondaryText(ctx)
 		}
 		if event.Rune() == 113 || event.Key() == tcell.KeyEscape { // q
 			logMutex.Lock()
@@ -667,17 +770,7 @@ func main() {
 				blockTextView.Clear()
 				blockTextView.SetText(blockText)
 			}
-			tmpText = getPeerText(ctx)
-			if tmpText != "" && tmpText != peerText {
-				peerText = tmpText
-				peerTextView.Clear()
-				peerTextView.SetText(peerText)
-				// Scroll to the top only once
-				if scrollPeers {
-					scrollPeers = false
-					peerTextView.ScrollToBeginning()
-				}
-			}
+			updateSecondaryText(ctx)
 			select {
 			case <-ctx.Done():
 				return
@@ -712,6 +805,138 @@ func getUptimes(ctx context.Context, processMetrics *process.Process) uint64 {
 		uptimes = 0 // Handle clock skew by showing 0 uptime
 	}
 	return uptimes
+}
+
+func formatDingoBytes(bytes uint64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%dB", bytes)
+	}
+	div := float64(unit)
+	exp := 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f%c", float64(bytes)/div, "KMGTPE"[exp])
+}
+
+func dingoCounterDelta(curr, prev uint64) uint64 {
+	if curr < prev {
+		return curr
+	}
+	return curr - prev
+}
+
+func formatDingoHitRatio(currHits, currMiss, prevHits, prevMiss uint64) string {
+	hits := dingoCounterDelta(currHits, prevHits)
+	misses := dingoCounterDelta(currMiss, prevMiss)
+	total := hits + misses
+	if total == 0 {
+		return "n/a"
+	}
+	return fmt.Sprintf("%.1f%%", float64(hits)/float64(total)*100)
+}
+
+func formatDingoRate(curr, prev uint64, dt time.Duration) string {
+	if dt <= 0 {
+		return "n/a"
+	}
+	rate := float64(dingoCounterDelta(curr, prev)) / dt.Seconds()
+	return fmt.Sprintf("%.0f", math.Round(rate))
+}
+
+func getDingoStats() string {
+	if promMetrics == nil {
+		return ""
+	}
+
+	curr := *promMetrics
+	currSrc := promMetrics
+	now := time.Now()
+
+	lastDingoSampleMu.Lock()
+	if currSrc != lastDingoSampleSrc {
+		lastDingoRateBase = lastDingoSample
+		lastDingoRateBaseAt = lastDingoSampleAt
+		lastDingoSample = &curr
+		lastDingoSampleAt = now
+		lastDingoSampleSrc = currSrc
+	}
+	prev := lastDingoRateBase
+	prevAt := lastDingoRateBaseAt
+	lastDingoSampleMu.Unlock()
+
+	prevMetrics := &PromMetrics{}
+	dt := time.Duration(0)
+	if prev != nil {
+		prevMetrics = prev
+		dt = now.Sub(prevAt)
+	}
+
+	utxoRatio := formatDingoHitRatio(
+		curr.DingoCacheUtxoHotHits,
+		curr.DingoCacheUtxoHotMiss,
+		prevMetrics.DingoCacheUtxoHotHits,
+		prevMetrics.DingoCacheUtxoHotMiss,
+	)
+	txRatio := formatDingoHitRatio(
+		curr.DingoCacheTxHotHits,
+		curr.DingoCacheTxHotMiss,
+		prevMetrics.DingoCacheTxHotHits,
+		prevMetrics.DingoCacheTxHotMiss,
+	)
+	blockRatio := formatDingoHitRatio(
+		curr.DingoCacheBlockLruHits,
+		curr.DingoCacheBlockLruMiss,
+		prevMetrics.DingoCacheBlockLruHits,
+		prevMetrics.DingoCacheBlockLruMiss,
+	)
+	coldExtractRate := "n/a"
+	eventErrorRate := "n/a"
+	eventTimeoutRate := "n/a"
+	if prev != nil {
+		coldExtractRate = formatDingoRate(
+			curr.DingoCacheColdExtract,
+			prevMetrics.DingoCacheColdExtract,
+			dt,
+		)
+		eventErrorRate = formatDingoRate(
+			curr.EventDeliveryErrors,
+			prevMetrics.EventDeliveryErrors,
+			dt,
+		)
+		eventTimeoutRate = formatDingoRate(
+			curr.EventDeliveryTimeouts,
+			prevMetrics.EventDeliveryTimeouts,
+			dt,
+		)
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, " [green]DB Size      : [white]%s\n",
+		formatDingoBytes(curr.DingoDbSizeBytes))
+	fmt.Fprintf(&sb, " [green]Cached Blocks: [white]%d\n",
+		curr.DingoChainCachedBlocks)
+	fmt.Fprintf(&sb, " [green]Tip Gap      : [white]%d[blue] slots[white]         [green]Forge Gap: [white]%d\n",
+		curr.DingoTipGapSlots,
+		curr.DingoForgeTipGapSlots)
+	fmt.Fprintf(&sb, " [green]CBOR Cache   : [white]utxo %s  tx %s  blk %s\n",
+		utxoRatio,
+		txRatio,
+		blockRatio)
+	fmt.Fprintf(&sb, " [green]Cold Extract : [white]%s[blue] / sec\n",
+		coldExtractRate)
+	fmt.Fprintf(&sb, " [green]Events       : [white]%d[blue] subs[white]   [green]total [white]%d[white]   [green]err [white]%s[blue]/s[white]   [green]timeout [white]%s[blue]/s\n",
+		curr.EventSubscribers,
+		curr.EventTotal,
+		eventErrorRate,
+		eventTimeoutRate)
+	fmt.Fprintf(&sb, " [green]Slot Clock   : [white]fallback %d   forgeErr %d   syncSkip %d\n",
+		curr.DingoSlotClockFallback,
+		curr.DingoForgeSlotClockErr,
+		curr.DingoForgeSyncSkip)
+	return sb.String()
 }
 
 func getEpochProgress() float32 {
@@ -1106,8 +1331,8 @@ func getPeerText(ctx context.Context) string {
 	charUnmarked = string('▖')
 	granularity := ProgressBarGranularity
 	granularitySmall := granularity / 2
-	if checkPeers {
-		peerCount := len(peersFiltered)
+	peerCount := len(peersFiltered)
+	if peerCount == 0 || len(peerStats.RTTresultsSlice) < peerCount {
 		fmt.Fprintf(&sb, " [yellow]%s [blue]%d[white]/[green]%d[white]\n",
 			"Peer analysis started... please wait!",
 			len(peerStats.RTTresultsSlice),
@@ -1116,7 +1341,6 @@ func getPeerText(ctx context.Context) string {
 		return sb.String()
 	}
 
-	peerCount := len(peersFiltered)
 	sb.WriteString("       [green]RTT : Peers / Percent\n")
 	fmt.Fprintf(&sb, "    [green]0-50ms : [white]%5s   %.f%%",
 		strconv.Itoa(peerStats.CNT1),

--- a/main_test.go
+++ b/main_test.go
@@ -954,6 +954,52 @@ func TestGetDingoStatsRendersDiagnostics(t *testing.T) {
 	}
 }
 
+func TestGetDingoStatsFirstSampleShowsUnavailableDeltas(t *testing.T) {
+	originalPromMetrics := promMetrics
+	originalLastDingoSample := lastDingoSample
+	originalLastDingoSampleAt := lastDingoSampleAt
+	originalLastDingoRateBase := lastDingoRateBase
+	originalLastDingoRateBaseAt := lastDingoRateBaseAt
+	originalLastDingoSampleSrc := lastDingoSampleSrc
+	defer func() {
+		promMetrics = originalPromMetrics
+		lastDingoSample = originalLastDingoSample
+		lastDingoSampleAt = originalLastDingoSampleAt
+		lastDingoRateBase = originalLastDingoRateBase
+		lastDingoRateBaseAt = originalLastDingoRateBaseAt
+		lastDingoSampleSrc = originalLastDingoSampleSrc
+	}()
+
+	lastDingoSample = nil
+	lastDingoSampleAt = time.Time{}
+	lastDingoRateBase = nil
+	lastDingoRateBaseAt = time.Time{}
+	lastDingoSampleSrc = nil
+	promMetrics = &PromMetrics{
+		DingoCacheUtxoHotHits:  100,
+		DingoCacheTxHotHits:    100,
+		DingoCacheBlockLruHits: 100,
+		DingoCacheColdExtract:  100,
+		EventDeliveryErrors:    100,
+		EventDeliveryTimeouts:  100,
+	}
+
+	result := getDingoStats()
+	expectedParts := []string{
+		"utxo n/a",
+		"tx n/a",
+		"blk n/a",
+		"Cold Extract : [white]n/a",
+		"err [white]n/a",
+		"timeout [white]n/a",
+	}
+	for _, part := range expectedParts {
+		if !strings.Contains(result, part) {
+			t.Errorf("getDingoStats() missing %q in:\n%s", part, result)
+		}
+	}
+}
+
 func BenchmarkGetEpochProgress(b *testing.B) {
 	// Set up config
 	cfg := config.GetConfig()

--- a/main_test.go
+++ b/main_test.go
@@ -741,6 +741,219 @@ func TestTcpinfoRtt(t *testing.T) {
 	}
 }
 
+// TestFormatDingoHitRatio verifies cache hit percentages are calculated from
+// previous-sample deltas instead of cumulative counter totals.
+func TestFormatDingoHitRatio(t *testing.T) {
+	tests := []struct {
+		name     string
+		currHits uint64
+		currMiss uint64
+		prevHits uint64
+		prevMiss uint64
+		expected string
+	}{
+		{
+			name:     "zero sample",
+			expected: "n/a",
+		},
+		{
+			name:     "growing hits and misses",
+			currHits: 150,
+			currMiss: 50,
+			prevHits: 100,
+			prevMiss: 25,
+			expected: "66.7%",
+		},
+		{
+			name:     "steady state",
+			currHits: 100,
+			currMiss: 25,
+			prevHits: 100,
+			prevMiss: 25,
+			expected: "n/a",
+		},
+		{
+			name:     "cumulative only misses",
+			currMiss: 10,
+			expected: "0.0%",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := formatDingoHitRatio(
+				tt.currHits,
+				tt.currMiss,
+				tt.prevHits,
+				tt.prevMiss,
+			)
+			if result != tt.expected {
+				t.Errorf(
+					"formatDingoHitRatio() = %q, expected %q",
+					result,
+					tt.expected,
+				)
+			}
+		})
+	}
+}
+
+// TestFormatDingoRate verifies cumulative Dingo counters are converted into
+// per-second rates using the elapsed time between samples.
+func TestFormatDingoRate(t *testing.T) {
+	result := formatDingoRate(22, 10, 3*time.Second)
+	if result != "4" {
+		t.Errorf("formatDingoRate() = %q, expected %q", result, "4")
+	}
+}
+
+// TestApplyDefaultSecondaryView verifies the first-scrape secondary pane
+// default and the NVIEW_DEFAULT_VIEW override behavior.
+func TestApplyDefaultSecondaryView(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		binary   string
+		expected secondaryView
+	}{
+		{
+			name:     "auto dingo",
+			binary:   DINGO_BINARY,
+			expected: viewDingo,
+		},
+		{
+			name:     "auto non-dingo",
+			binary:   CARDANO_BINARY,
+			expected: viewNone,
+		},
+		{
+			name:     "peers override",
+			envValue: "peers",
+			binary:   DINGO_BINARY,
+			expected: viewPeers,
+		},
+		{
+			name:     "none override",
+			envValue: "none",
+			binary:   DINGO_BINARY,
+			expected: viewNone,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("NVIEW_DEFAULT_VIEW", tt.envValue)
+			cfg := config.GetConfig()
+			originalBinary := cfg.Node.Binary
+			originalDefaultSet := secondaryDefaultSet.Load()
+			originalActive := getActiveSecondaryView()
+			defer func() {
+				cfg.Node.Binary = originalBinary
+				secondaryDefaultSet.Store(originalDefaultSet)
+				setActiveSecondaryView(originalActive)
+				detectedNodeBinary.Store("")
+			}()
+
+			cfg.Node.Binary = ""
+			detectedNodeBinary.Store(tt.binary)
+			secondaryDefaultSet.Store(false)
+			setActiveSecondaryView(viewPeers)
+
+			applyDefaultSecondaryView()
+
+			if getActiveSecondaryView() != tt.expected {
+				t.Errorf(
+					"active secondary = %d, expected %d",
+					getActiveSecondaryView(),
+					tt.expected,
+				)
+			}
+		})
+	}
+}
+
+// TestGetDingoStatsRendersDiagnostics verifies the diagnostics pane renders
+// Dingo-native values plus derived cache ratios and event/cold-extract rates.
+func TestGetDingoStatsRendersDiagnostics(t *testing.T) {
+	originalPromMetrics := promMetrics
+	originalLastDingoSample := lastDingoSample
+	originalLastDingoSampleAt := lastDingoSampleAt
+	originalLastDingoRateBase := lastDingoRateBase
+	originalLastDingoRateBaseAt := lastDingoRateBaseAt
+	originalLastDingoSampleSrc := lastDingoSampleSrc
+	defer func() {
+		promMetrics = originalPromMetrics
+		lastDingoSample = originalLastDingoSample
+		lastDingoSampleAt = originalLastDingoSampleAt
+		lastDingoRateBase = originalLastDingoRateBase
+		lastDingoRateBaseAt = originalLastDingoRateBaseAt
+		lastDingoSampleSrc = originalLastDingoSampleSrc
+	}()
+
+	lastDingoRateBase = nil
+	lastDingoRateBaseAt = time.Time{}
+	lastDingoSampleSrc = nil
+	lastDingoSample = &PromMetrics{
+		DingoCacheUtxoHotHits:  90,
+		DingoCacheUtxoHotMiss:  10,
+		DingoCacheTxHotHits:    40,
+		DingoCacheTxHotMiss:    10,
+		DingoCacheBlockLruHits: 5,
+		DingoCacheBlockLruMiss: 5,
+		DingoCacheColdExtract:  10,
+		EventDeliveryErrors:    1,
+		EventDeliveryTimeouts:  2,
+	}
+	lastDingoSampleAt = time.Now().Add(-10 * time.Second)
+	promMetrics = &PromMetrics{
+		DingoDbSizeBytes:       BytesInGigabyte,
+		DingoChainCachedBlocks: 8192,
+		DingoTipGapSlots:       0,
+		DingoForgeTipGapSlots:  1,
+		DingoSlotClockFallback: 2,
+		DingoForgeSlotClockErr: 3,
+		DingoForgeSyncSkip:     4,
+		DingoCacheUtxoHotHits:  188,
+		DingoCacheUtxoHotMiss:  12,
+		DingoCacheTxHotHits:    131,
+		DingoCacheTxHotMiss:    19,
+		DingoCacheBlockLruHits: 81,
+		DingoCacheBlockLruMiss: 29,
+		DingoCacheColdExtract:  130,
+		EventTotal:             100,
+		EventSubscribers:       14,
+		EventDeliveryErrors:    1,
+		EventDeliveryTimeouts:  2,
+	}
+
+	result := getDingoStats()
+	expectedParts := []string{
+		"DB Size",
+		"1.0G",
+		"Cached Blocks",
+		"8192",
+		"Tip Gap",
+		"Forge Gap",
+		"CBOR Cache",
+		"utxo 98.0%",
+		"tx 91.0%",
+		"blk 76.0%",
+		"Cold Extract",
+		"12",
+		"Events",
+		"14",
+		"Slot Clock",
+		"fallback 2",
+		"forgeErr 3",
+		"syncSkip 4",
+	}
+	for _, part := range expectedParts {
+		if !strings.Contains(result, part) {
+			t.Errorf("getDingoStats() missing %q in:\n%s", part, result)
+		}
+	}
+}
+
 func BenchmarkGetEpochProgress(b *testing.B) {
 	// Set up config
 	cfg := config.GetConfig()

--- a/peers.go
+++ b/peers.go
@@ -32,7 +32,6 @@ import (
 var peersFiltered []string
 
 var (
-	checkPeers      bool = true
 	scrollPeers     bool = false
 	peersFilteredMu sync.RWMutex
 	peerStatsMu     sync.Mutex
@@ -183,131 +182,133 @@ func filterPeers(ctx context.Context) error {
 }
 
 func pingPeers(ctx context.Context) error {
+	if getActiveSecondaryView() != viewPeers {
+		failCount.Store(0)
+		return nil
+	}
+
 	scrollPeers = false
 	granularity := 68
 	granularitySmall := granularity / 2
-	if checkPeers {
-		// counters, etc.
-		var wg sync.WaitGroup
-		peersFilteredMu.RLock()
-		peerCount := len(peersFiltered)
-		if peerCount == 0 {
-			peersFilteredMu.RUnlock()
-			return errors.New("no peers to ping")
-		}
-		for _, v := range peersFiltered {
-			// increment waitgroup counter
-			wg.Add(1)
+	// counters, etc.
+	var wg sync.WaitGroup
+	peersFilteredMu.RLock()
+	peerCount := len(peersFiltered)
+	if peerCount == 0 {
+		peersFilteredMu.RUnlock()
+		return errors.New("no peers to ping")
+	}
+	for _, v := range peersFiltered {
+		// increment waitgroup counter
+		wg.Add(1)
 
-			go func(v string) {
-				defer wg.Done()
-				peerArr := strings.Split(v, ";")
-				if len(peerArr) < 3 {
+		go func(v string) {
+			defer wg.Done()
+			peerArr := strings.Split(v, ";")
+			if len(peerArr) < 3 {
+				return
+			}
+			peerIP := peerArr[0]
+			peerPORT := peerArr[1]
+			peerDIR := peerArr[2]
+
+			// Return early if we've been checked recently
+			now := time.Now()
+			expire := now.Add(-600 * time.Second)
+			peerStatsMu.Lock()
+			existing, ok := peerStats.RTTresultsMap[peerIP]
+			peerStatsMu.Unlock()
+			if ok {
+				if existing.UpdatedAt.After(expire) && existing.RTT != 0 {
 					return
 				}
-				peerIP := peerArr[0]
-				peerPORT := peerArr[1]
-				peerDIR := peerArr[2]
-
-				// Return early if we've been checked recently
-				now := time.Now()
-				expire := now.Add(-600 * time.Second)
-				peerStatsMu.Lock()
-				existing, ok := peerStats.RTTresultsMap[peerIP]
-				peerStatsMu.Unlock()
-				if ok {
-					if existing.UpdatedAt.After(expire) && existing.RTT != 0 {
-						return
-					}
-					if existing.Location != "---" {
-						return
-					}
+				if existing.Location != "---" {
+					return
 				}
-				peerStatsMu.Lock()
-				if len(peerStats.RTTresultsMap) == 0 {
-					peerStats.RTTresultsMap = make(
-						peerRTTresultsMap,
-						peerCount,
-					)
-				}
-				peerStatsMu.Unlock()
-
-				// Start RTT loop
-				// for tool in ... return peerRTT
-				peerRTT := tcpinfoRtt(fmt.Sprintf("%s:%s", peerIP, peerPORT))
-				peerPort, err := strconv.Atoi(peerPORT)
-				if err != nil {
-					peerPort = 0
-				}
-				peerLocation := getGeoIP(ctx, peerIP)
-				peer := &Peer{
-					IP:        peerIP,
-					Port:      peerPort,
-					Direction: peerDIR,
-					RTT:       peerRTT,
-					Location:  peerLocation,
-					UpdatedAt: time.Now(),
-				}
-				peerStatsMu.Lock()
-				if peerRTT != 99999 {
-					peerStats.RTTSUM += peerRTT
-				}
-				// Update counters
-				if peerRTT < 50 {
-					peerStats.CNT1++
-				} else if peerRTT < 100 {
-					peerStats.CNT2++
-				} else if peerRTT < 200 {
-					peerStats.CNT3++
-				} else if peerRTT < 99999 {
-					peerStats.CNT4++
-				} else {
-					peerStats.CNT0++
-				}
-				peerStats.RTTresultsMap[peerIP] = peer
-				peerStats.RTTresultsSlice = append(
-					peerStats.RTTresultsSlice,
-					peer,
+			}
+			peerStatsMu.Lock()
+			if len(peerStats.RTTresultsMap) == 0 {
+				peerStats.RTTresultsMap = make(
+					peerRTTresultsMap,
+					peerCount,
 				)
-				sort.Sort(peerStats.RTTresultsSlice)
-				peerStatsMu.Unlock()
-			}(v)
-		}
-		peersFilteredMu.RUnlock()
-		wg.Wait()
-		peerCNTreachable := peerCount - peerStats.CNT0
-		if peerCNTreachable > 0 {
-			peerStats.RTTAVG = peerStats.RTTSUM / peerCNTreachable
-			peerStats.PCT1 = float32(
-				peerStats.CNT1,
-			) / float32(
-				peerCNTreachable,
-			) * 100
-			peerStats.PCT1items = int(peerStats.PCT1) * granularitySmall / 100
-			peerStats.PCT2 = float32(
-				peerStats.CNT2,
-			) / float32(
-				peerCNTreachable,
-			) * 100
-			peerStats.PCT2items = int(peerStats.PCT2) * granularitySmall / 100
-			peerStats.PCT3 = float32(
-				peerStats.CNT3,
-			) / float32(
-				peerCNTreachable,
-			) * 100
-			peerStats.PCT3items = int(peerStats.PCT3) * granularitySmall / 100
-			peerStats.PCT4 = float32(
-				peerStats.CNT4,
-			) / float32(
-				peerCNTreachable,
-			) * 100
-			peerStats.PCT4items = int(peerStats.PCT4) * granularitySmall / 100
-		}
-		if len(peerStats.RTTresultsSlice) != 0 &&
-			len(peerStats.RTTresultsSlice) >= peerCount {
-			checkPeers = false
-			scrollPeers = true
-		}
+			}
+			peerStatsMu.Unlock()
+
+			// Start RTT loop
+			// for tool in ... return peerRTT
+			peerRTT := tcpinfoRtt(fmt.Sprintf("%s:%s", peerIP, peerPORT))
+			peerPort, err := strconv.Atoi(peerPORT)
+			if err != nil {
+				peerPort = 0
+			}
+			peerLocation := getGeoIP(ctx, peerIP)
+			peer := &Peer{
+				IP:        peerIP,
+				Port:      peerPort,
+				Direction: peerDIR,
+				RTT:       peerRTT,
+				Location:  peerLocation,
+				UpdatedAt: time.Now(),
+			}
+			peerStatsMu.Lock()
+			if peerRTT != 99999 {
+				peerStats.RTTSUM += peerRTT
+			}
+			// Update counters
+			if peerRTT < 50 {
+				peerStats.CNT1++
+			} else if peerRTT < 100 {
+				peerStats.CNT2++
+			} else if peerRTT < 200 {
+				peerStats.CNT3++
+			} else if peerRTT < 99999 {
+				peerStats.CNT4++
+			} else {
+				peerStats.CNT0++
+			}
+			peerStats.RTTresultsMap[peerIP] = peer
+			peerStats.RTTresultsSlice = append(
+				peerStats.RTTresultsSlice,
+				peer,
+			)
+			sort.Sort(peerStats.RTTresultsSlice)
+			peerStatsMu.Unlock()
+		}(v)
+	}
+	peersFilteredMu.RUnlock()
+	wg.Wait()
+	peerCNTreachable := peerCount - peerStats.CNT0
+	if peerCNTreachable > 0 {
+		peerStats.RTTAVG = peerStats.RTTSUM / peerCNTreachable
+		peerStats.PCT1 = float32(
+			peerStats.CNT1,
+		) / float32(
+			peerCNTreachable,
+		) * 100
+		peerStats.PCT1items = int(peerStats.PCT1) * granularitySmall / 100
+		peerStats.PCT2 = float32(
+			peerStats.CNT2,
+		) / float32(
+			peerCNTreachable,
+		) * 100
+		peerStats.PCT2items = int(peerStats.PCT2) * granularitySmall / 100
+		peerStats.PCT3 = float32(
+			peerStats.CNT3,
+		) / float32(
+			peerCNTreachable,
+		) * 100
+		peerStats.PCT3items = int(peerStats.PCT3) * granularitySmall / 100
+		peerStats.PCT4 = float32(
+			peerStats.CNT4,
+		) / float32(
+			peerCNTreachable,
+		) * 100
+		peerStats.PCT4items = int(peerStats.PCT4) * granularitySmall / 100
+	}
+	if len(peerStats.RTTresultsSlice) != 0 &&
+		len(peerStats.RTTresultsSlice) >= peerCount {
+		scrollPeers = true
 	}
 	failCount.Store(0)
 	return nil

--- a/peers.go
+++ b/peers.go
@@ -181,10 +181,10 @@ func filterPeers(ctx context.Context) error {
 	return nil
 }
 
-func pingPeers(ctx context.Context) error {
+func pingPeers(ctx context.Context) {
 	if getActiveSecondaryView() != viewPeers {
 		failCount.Store(0)
-		return nil
+		return
 	}
 
 	scrollPeers = false
@@ -196,7 +196,7 @@ func pingPeers(ctx context.Context) error {
 	peerCount := len(peersFiltered)
 	if peerCount == 0 {
 		peersFilteredMu.RUnlock()
-		return nil
+		return
 	}
 	for _, v := range peersFiltered {
 		// increment waitgroup counter
@@ -308,7 +308,6 @@ func pingPeers(ctx context.Context) error {
 		scrollPeers = true
 	}
 	failCount.Store(0)
-	return nil
 }
 
 func resetPeers() {

--- a/peers.go
+++ b/peers.go
@@ -196,7 +196,7 @@ func pingPeers(ctx context.Context) error {
 	peerCount := len(peersFiltered)
 	if peerCount == 0 {
 		peersFilteredMu.RUnlock()
-		return errors.New("no peers to ping")
+		return nil
 	}
 	for _, v := range peersFiltered {
 		// increment waitgroup counter
@@ -219,10 +219,7 @@ func pingPeers(ctx context.Context) error {
 			existing, ok := peerStats.RTTresultsMap[peerIP]
 			peerStatsMu.Unlock()
 			if ok {
-				if existing.UpdatedAt.After(expire) && existing.RTT != 0 {
-					return
-				}
-				if existing.Location != "---" {
+				if existing.UpdatedAt.After(expire) && existing.RTT != 0 && existing.Location != "---" {
 					return
 				}
 			}

--- a/prometheus.go
+++ b/prometheus.go
@@ -205,16 +205,17 @@ func prom2json(prom []byte) ([]byte, error) {
 	}
 	for _, val := range families {
 		for _, m := range val.GetMetric() {
+			name := val.GetName()
 			switch val.GetType() {
 			case dto.MetricType_COUNTER:
-				out[val.GetName()] = m.GetCounter().GetValue()
+				setPromMetricValue(out, name, m.GetCounter().GetValue())
 			case dto.MetricType_GAUGE:
-				out[val.GetName()] = m.GetGauge().GetValue()
+				setPromMetricValue(out, name, m.GetGauge().GetValue())
 			case dto.MetricType_UNTYPED:
-				out[val.GetName()] = m.GetUntyped().GetValue()
+				setPromMetricValue(out, name, m.GetUntyped().GetValue())
 			case dto.MetricType_SUMMARY:
 				// Extract count from SUMMARY metrics (e.g. go_gc_duration_seconds_count)
-				out[val.GetName()+"_count"] = m.GetSummary().GetSampleCount()
+				out[name+"_count"] = m.GetSummary().GetSampleCount()
 			case dto.MetricType_HISTOGRAM,
 				dto.MetricType_GAUGE_HISTOGRAM:
 				// Skip unsupported metric types
@@ -228,4 +229,13 @@ func prom2json(prom []byte) ([]byte, error) {
 		return b, err
 	}
 	return b, nil
+}
+
+func setPromMetricValue(out map[string]any, name string, value float64) {
+	if strings.HasPrefix(name, "event_") {
+		if prev, ok := out[name].(float64); ok {
+			value += prev
+		}
+	}
+	out[name] = value
 }

--- a/prometheus.go
+++ b/prometheus.go
@@ -89,6 +89,30 @@ type PromMetrics struct {
 	GoGcCount             uint64 `json:"go_gc_duration_seconds_count"`
 	DingoShelleyStartTime uint64 `json:"dingo_shelley_start_time"`
 	DingoEpochLengthSlots uint64 `json:"dingo_epoch_length_slots"`
+
+	// Dingo-native metrics
+	DingoDbSizeBytes       uint64 `json:"dingo_database_size_bytes"`
+	DingoChainCachedBlocks uint64 `json:"dingo_chain_manager_cached_blocks"`
+	DingoTipGapSlots       uint64 `json:"dingo_tip_gap_slots"`
+	DingoForgeTipGapSlots  uint64 `json:"dingo_forge_tip_gap_slots"`
+	DingoSlotClockFallback uint64 `json:"dingo_ledger_slot_clock_fallback_total"`
+	DingoForgeSlotClockErr uint64 `json:"dingo_forge_slot_clock_errors_total"`
+	DingoForgeSyncSkip     uint64 `json:"dingo_forge_sync_skip_total"`
+
+	// CBOR cache counters (cumulative)
+	DingoCacheUtxoHotHits  uint64 `json:"dingo_cbor_cache_utxo_hot_hits_total"`
+	DingoCacheUtxoHotMiss  uint64 `json:"dingo_cbor_cache_utxo_hot_misses_total"`
+	DingoCacheTxHotHits    uint64 `json:"dingo_cbor_cache_tx_hot_hits_total"`
+	DingoCacheTxHotMiss    uint64 `json:"dingo_cbor_cache_tx_hot_misses_total"`
+	DingoCacheBlockLruHits uint64 `json:"dingo_cbor_cache_block_lru_hits_total"`
+	DingoCacheBlockLruMiss uint64 `json:"dingo_cbor_cache_block_lru_misses_total"`
+	DingoCacheColdExtract  uint64 `json:"dingo_cbor_cache_cold_extractions_total"`
+
+	// Event bus
+	EventTotal            uint64 `json:"event_total"`
+	EventSubscribers      uint64 `json:"event_subscribers"`
+	EventDeliveryErrors   uint64 `json:"event_delivery_errors_total"`
+	EventDeliveryTimeouts uint64 `json:"event_delivery_timeouts_total"`
 }
 
 // Gets metrics from prometheus and return a PromMetrics instance

--- a/prometheus_test.go
+++ b/prometheus_test.go
@@ -221,6 +221,66 @@ dingo_epoch_length_slots 1000
 	}
 }
 
+// TestPromMetricsPopulatesAllDingoDiagnosticsFields verifies every new Dingo
+// and event-bus Prometheus metric is decoded into the PromMetrics struct.
+func TestPromMetricsPopulatesAllDingoDiagnosticsFields(t *testing.T) {
+	prom := []byte(`
+dingo_database_size_bytes{plugin="ledger"} 1337
+dingo_chain_manager_cached_blocks 8192
+dingo_tip_gap_slots 2
+dingo_forge_tip_gap_slots 3
+dingo_ledger_slot_clock_fallback_total 4
+dingo_forge_slot_clock_errors_total 5
+dingo_forge_sync_skip_total 6
+dingo_cbor_cache_utxo_hot_hits_total 100
+dingo_cbor_cache_utxo_hot_misses_total 10
+dingo_cbor_cache_tx_hot_hits_total 200
+dingo_cbor_cache_tx_hot_misses_total 20
+dingo_cbor_cache_block_lru_hits_total 300
+dingo_cbor_cache_block_lru_misses_total 30
+dingo_cbor_cache_cold_extractions_total 40
+event_total 50
+event_subscribers 60
+event_delivery_errors_total 70
+event_delivery_timeouts_total 80
+`)
+
+	metrics := decodePromMetrics(t, prom)
+
+	tests := []struct {
+		name string
+		got  uint64
+		want uint64
+	}{
+		{"DingoDbSizeBytes", metrics.DingoDbSizeBytes, 1337},
+		{"DingoChainCachedBlocks", metrics.DingoChainCachedBlocks, 8192},
+		{"DingoTipGapSlots", metrics.DingoTipGapSlots, 2},
+		{"DingoForgeTipGapSlots", metrics.DingoForgeTipGapSlots, 3},
+		{"DingoSlotClockFallback", metrics.DingoSlotClockFallback, 4},
+		{"DingoForgeSlotClockErr", metrics.DingoForgeSlotClockErr, 5},
+		{"DingoForgeSyncSkip", metrics.DingoForgeSyncSkip, 6},
+		{"DingoCacheUtxoHotHits", metrics.DingoCacheUtxoHotHits, 100},
+		{"DingoCacheUtxoHotMiss", metrics.DingoCacheUtxoHotMiss, 10},
+		{"DingoCacheTxHotHits", metrics.DingoCacheTxHotHits, 200},
+		{"DingoCacheTxHotMiss", metrics.DingoCacheTxHotMiss, 20},
+		{"DingoCacheBlockLruHits", metrics.DingoCacheBlockLruHits, 300},
+		{"DingoCacheBlockLruMiss", metrics.DingoCacheBlockLruMiss, 30},
+		{"DingoCacheColdExtract", metrics.DingoCacheColdExtract, 40},
+		{"EventTotal", metrics.EventTotal, 50},
+		{"EventSubscribers", metrics.EventSubscribers, 60},
+		{"EventDeliveryErrors", metrics.EventDeliveryErrors, 70},
+		{"EventDeliveryTimeouts", metrics.EventDeliveryTimeouts, 80},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("%s = %d, expected %d", tt.name, tt.got, tt.want)
+			}
+		})
+	}
+}
+
 func decodePromMetrics(t *testing.T, prom []byte) PromMetrics {
 	t.Helper()
 

--- a/prometheus_test.go
+++ b/prometheus_test.go
@@ -239,10 +239,14 @@ dingo_cbor_cache_tx_hot_misses_total 20
 dingo_cbor_cache_block_lru_hits_total 300
 dingo_cbor_cache_block_lru_misses_total 30
 dingo_cbor_cache_cold_extractions_total 40
-event_total 50
-event_subscribers 60
-event_delivery_errors_total 70
-event_delivery_timeouts_total 80
+event_total{type="block"} 20
+event_total{type="tx"} 30
+event_subscribers{topic="block"} 25
+event_subscribers{topic="tx"} 35
+event_delivery_errors_total{topic="block"} 30
+event_delivery_errors_total{topic="tx"} 40
+event_delivery_timeouts_total{topic="block"} 35
+event_delivery_timeouts_total{topic="tx"} 45
 `)
 
 	metrics := decodePromMetrics(t, prom)


### PR DESCRIPTION
1. Added secondaryView state with viewNone, viewPeers, and viewDingo.
2. Made changes for p and d keybindings to switch between peer analysis, Dingo diagnostics, and no secondary view.
3. Added NVIEW_DEFAULT_VIEW=peers|dingo|none to override the default pane.
4. I have gated peer RTT scans so they only run when the peer view is active.
5. Added Dingo/Event Prometheus fields and a getDingoStats() renderer.
6. Made changes for rendering DB size, cache stats, tip gaps, event-bus health, and slot-clock counters.
7. Calculated cache ratios and rates from previous-sample deltas and made some fixes for footer wrapping after adding the Dingo keybind.
8. Added unit tests for metrics parsing, Dingo renderer output, ratio/rate math, and default view selection.

Closes #447 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Diagnostics secondary view for Dingo nodes and a toggleable secondary pane (Peers/Dingo/None). Implements Linear #447, gates peer scans to the Peers view, extends Prometheus decoding (with aggregated `event_*` metrics), and suppresses stderr logs while the TUI runs.

- New Features
  - Secondary view state: none, peers, dingo. Toggle with p (Peers) and d (Dingo). Title updates per view.
  - Default pane via NVIEW_DEFAULT_VIEW=peers|dingo|none; auto-defaults to Dingo on Dingo binaries, otherwise none. Ignores `dingo` default on non-Dingo nodes.
  - Diagnostics renderer: DB size, cached blocks, tip/forge gaps, CBOR cache hit ratios, cold extract rate, event error/timeout rates, slot-clock counters. Ratios/rates use previous-sample deltas. Prometheus decoding adds Dingo + event-bus fields and aggregates labeled `event_*` metrics.

- Bug Fixes
  - Gated peer RTT/GeoIP scans to only run when the Peers view is active; improved locking and progress display.
  - Fixed footer wrapping and updated footer to show p/d keybinds; silenced stderr logs during TUI.
  - Addressed lint issues and added tests for diagnostics rendering, ratio/rate math, default view selection, and Prometheus field coverage.

<sup>Written for commit 82148d1653f11cf32ae64785cff4cc95e207d361. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/nview/pull/453?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a secondary view system with Peers analysis and Dingo Diagnostics; press 'p' to toggle Peers and 'd' to toggle Dingo Diagnostics (only on Dingo nodes).
  * Dingo Diagnostics shows cache hit ratios, event metrics, slot-clock and related statistics.
  * Default secondary view configurable via environment variable.

* **Improvements**
  * Footer help updated to include 'p' and 'd'; secondary panel refreshes more consistently.

* **Tests**
  * Added tests covering view defaults, diagnostics rendering, and metric formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/nview/pull/453?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->