### PR TITLE
fix(dingo): container-aware process discovery + multi-instance disambiguation

### DIFF
--- a/main.go
+++ b/main.go
@@ -1414,7 +1414,7 @@ func findDingoProcess(
 			// name-only fallback and warn when there is real ambiguity.
 			selected, ok := lowestPIDDingoCandidate(candidates)
 			if !ok {
-				return nil, fmt.Errorf("no dingo process found")
+				return nil, errors.New("no dingo process found")
 			}
 			if len(candidates) > 1 {
 				logDingoCandidateAmbiguity(

--- a/main.go
+++ b/main.go
@@ -1381,19 +1381,45 @@ func findDingoProcess(
 		processes, err := lookups.listProcs(ctx, DINGO_BINARY)
 		if err == nil && len(processes) > 0 {
 			candidates := inspectDingoCandidates(ctx, processes)
-			if proc := findDingoCandidateByMetricsPort(
+			portMatches := dingoCandidatesByMetricsPort(
 				candidates,
 				cfg.Prometheus.Port,
-			); proc != nil {
+			)
+			if len(portMatches) == 1 {
+				proc := portMatches[0].proc
 				logDingoProcessSelection(proc.Pid, "cmdline-match")
 				return proc, nil
+			}
+			if len(portMatches) > 1 {
+				selected := lowestPIDDingoCandidate(portMatches)
+				logDingoCandidateAmbiguity(
+					fmt.Sprintf(
+						"multiple dingo processes declared metrics-port=%d, picked lowest pid=%d",
+						cfg.Prometheus.Port,
+						selected.proc.Pid,
+					),
+					selected,
+					portMatches,
+					cfg.Prometheus.Port,
+				)
+				logDingoProcessSelection(selected.proc.Pid, "cmdline-match")
+				return selected.proc, nil
 			}
 
 			// If no process declares the scrape port, use a deterministic
 			// name-only fallback and warn when there is real ambiguity.
 			selected := lowestPIDDingoCandidate(candidates)
 			if len(candidates) > 1 {
-				logMultipleDingoCandidates(selected, candidates, cfg.Prometheus.Port)
+				logDingoCandidateAmbiguity(
+					fmt.Sprintf(
+						"multiple dingo processes found, none declared metrics-port=%d, picked lowest pid=%d",
+						cfg.Prometheus.Port,
+						selected.proc.Pid,
+					),
+					selected,
+					candidates,
+					cfg.Prometheus.Port,
+				)
 			}
 			logDingoProcessSelection(selected.proc.Pid, "name-only")
 			return selected.proc, nil
@@ -1449,17 +1475,18 @@ func inspectDingoCandidates(
 	return candidates
 }
 
-func findDingoCandidateByMetricsPort(
+func dingoCandidatesByMetricsPort(
 	candidates []dingoCandidate,
 	port uint32,
-) *process.Process {
+) []dingoCandidate {
 	expected := strconv.FormatUint(uint64(port), 10)
+	matches := []dingoCandidate{}
 	for _, candidate := range candidates {
 		if candidate.metricsPort == expected {
-			return candidate.proc
+			matches = append(matches, candidate)
 		}
 	}
-	return nil
+	return matches
 }
 
 func lowestPIDDingoCandidate(candidates []dingoCandidate) dingoCandidate {
@@ -1531,7 +1558,8 @@ func logDingoProcessSelection(pid int32, method string) {
 	)
 }
 
-func logMultipleDingoCandidates(
+func logDingoCandidateAmbiguity(
+	message string,
 	selected dingoCandidate,
 	candidates []dingoCandidate,
 	port uint32,
@@ -1543,11 +1571,7 @@ func logMultipleDingoCandidates(
 		return
 	}
 	logger.Warn(
-		fmt.Sprintf(
-			"multiple dingo processes found, none declared metrics-port=%d, picked lowest pid=%d",
-			port,
-			selected.proc.Pid,
-		),
+		message,
 		"metrics-port",
 		port,
 		"picked-pid",

--- a/main.go
+++ b/main.go
@@ -123,6 +123,7 @@ func (h *bufferHandler) WithGroup(name string) slog.Handler {
 }
 
 var logger *slog.Logger
+var dingoProcessSelectionLogged atomic.Bool
 
 // Global command line flags
 var cmdlineFlags struct {
@@ -1316,7 +1317,7 @@ func getProcessMetrics(ctx context.Context) (*process.Process, error) {
 	cfg := config.GetConfig()
 
 	// If CARDANO_NODE_PID is specified, use it directly for all node types
-	if cfg.Node.Pid > 0 {
+	if cfg.Node.Pid > 0 && getEffectiveNodeBinary() != DINGO_BINARY {
 		return getProcessMetricsByPid(ctx, cfg.Node.Pid)
 	}
 
@@ -1324,19 +1325,289 @@ func getProcessMetrics(ctx context.Context) (*process.Process, error) {
 	case AMARU_BINARY:
 		return getProcessMetricsByPidFile(ctx, cfg)
 	case DINGO_BINARY:
-		// Use configured PID, defaulting to 1 if not set
-		pid := cfg.Node.Pid
-		if pid == 0 {
-			pid = 1
-		}
-		if proc, err := getProcessMetricsByPid(ctx, pid); err == nil {
-			return proc, nil
-		}
-		// Fall back to name-based search
-		return getProcessMetricsByName(ctx, cfg)
+		return findDingoProcess(ctx, cfg, defaultProcLookups())
 	default:
 		return getProcessMetricsByNameAndPort(ctx, cfg)
 	}
+}
+
+type procLookups struct {
+	socketOwner func(ctx context.Context, host string, port uint32) (int32, error)
+	listProcs   func(ctx context.Context, name string) ([]*process.Process, error)
+}
+
+func defaultProcLookups() procLookups {
+	return procLookups{
+		socketOwner: findTCPSocketOwner,
+		listProcs:   listProcessesByName,
+	}
+}
+
+func findDingoProcess(
+	ctx context.Context,
+	cfg *config.Config,
+	lookups procLookups,
+) (*process.Process, error) {
+	if cfg.Node.Pid > 0 {
+		proc, err := getProcessMetricsByPid(ctx, cfg.Node.Pid)
+		if err == nil {
+			logDingoProcessSelection(proc.Pid, "explicit-pid")
+		}
+		return proc, err
+	}
+
+	// Prefer the process that owns the Prometheus scrape socket. This is the
+	// strongest automatic signal because it is serving the metrics we read.
+	if lookups.socketOwner != nil {
+		pid, err := lookups.socketOwner(
+			ctx,
+			cfg.Prometheus.Host,
+			cfg.Prometheus.Port,
+		)
+		if err == nil && pid > 0 {
+			proc, err := getProcessMetricsByPid(ctx, pid)
+			if err == nil {
+				logDingoProcessSelection(proc.Pid, "socket-owner")
+				return proc, nil
+			}
+		}
+	}
+
+	// If socket ownership is unavailable, inspect named Dingo processes and
+	// select the one that declares the configured metrics port.
+	if lookups.listProcs != nil {
+		processes, err := lookups.listProcs(ctx, DINGO_BINARY)
+		if err == nil && len(processes) > 0 {
+			candidates := inspectDingoCandidates(ctx, processes)
+			if proc := findDingoCandidateByMetricsPort(
+				candidates,
+				cfg.Prometheus.Port,
+			); proc != nil {
+				logDingoProcessSelection(proc.Pid, "cmdline-match")
+				return proc, nil
+			}
+
+			// If no process declares the scrape port, use a deterministic
+			// name-only fallback and warn when there is real ambiguity.
+			selected := lowestPIDDingoCandidate(candidates)
+			if len(candidates) > 1 {
+				logMultipleDingoCandidates(selected, candidates, cfg.Prometheus.Port)
+			}
+			logDingoProcessSelection(selected.proc.Pid, "name-only")
+			return selected.proc, nil
+		}
+	}
+
+	// Last resort for single-process containers where Dingo is PID 1 but
+	// process enumeration did not find it.
+	proc, err := getProcessMetricsByPid(ctx, 1)
+	if err == nil {
+		logDingoProcessSelection(proc.Pid, "pid-1-fallback")
+	}
+	return proc, err
+}
+
+type dingoCandidate struct {
+	proc        *process.Process
+	metricsPort string
+	dataDir     string
+}
+
+// inspectDingoCandidates reads process metadata used to disambiguate multiple
+// Dingo instances without failing when cmdline or env access is denied.
+func inspectDingoCandidates(
+	ctx context.Context,
+	processes []*process.Process,
+) []dingoCandidate {
+	candidates := make([]dingoCandidate, 0, len(processes))
+	for _, proc := range processes {
+		candidate := dingoCandidate{
+			proc:        proc,
+			metricsPort: "-",
+			dataDir:     "-",
+		}
+
+		if args, err := proc.CmdlineSliceWithContext(ctx); err == nil {
+			if metricsPort := valueFromArgs(args, "--metrics-port"); metricsPort != "" {
+				candidate.metricsPort = metricsPort
+			}
+			if dataDir := valueFromArgs(args, "--data-dir"); dataDir != "" {
+				candidate.dataDir = dataDir
+			}
+		}
+
+		if env, err := proc.EnvironWithContext(ctx); err == nil {
+			if metricsPort := valueFromEnv(env, "DINGO_METRICS_PORT"); metricsPort != "" {
+				candidate.metricsPort = metricsPort
+			}
+		}
+
+		candidates = append(candidates, candidate)
+	}
+	return candidates
+}
+
+func findDingoCandidateByMetricsPort(
+	candidates []dingoCandidate,
+	port uint32,
+) *process.Process {
+	expected := strconv.FormatUint(uint64(port), 10)
+	for _, candidate := range candidates {
+		if candidate.metricsPort == expected {
+			return candidate.proc
+		}
+	}
+	return nil
+}
+
+func lowestPIDDingoCandidate(candidates []dingoCandidate) dingoCandidate {
+	selected := candidates[0]
+	for _, candidate := range candidates[1:] {
+		if candidate.proc.Pid < selected.proc.Pid {
+			selected = candidate
+		}
+	}
+	return selected
+}
+
+func valueFromArgs(args []string, flag string) string {
+	for i, arg := range args {
+		if arg == flag && i+1 < len(args) {
+			return args[i+1]
+		}
+		if strings.HasPrefix(arg, flag+"=") {
+			return strings.TrimPrefix(arg, flag+"=")
+		}
+	}
+	return ""
+}
+
+func valueFromEnv(env []string, name string) string {
+	prefix := name + "="
+	for _, item := range env {
+		if strings.HasPrefix(item, prefix) {
+			return strings.TrimPrefix(item, prefix)
+		}
+	}
+	return ""
+}
+
+func logDingoProcessSelection(pid int32, method string) {
+	if logger == nil {
+		return
+	}
+	if !dingoProcessSelectionLogged.CompareAndSwap(false, true) {
+		return
+	}
+	logger.Info(
+		"selected dingo process",
+		"pid",
+		pid,
+		"method",
+		method,
+	)
+}
+
+func logMultipleDingoCandidates(
+	selected dingoCandidate,
+	candidates []dingoCandidate,
+	port uint32,
+) {
+	if logger == nil {
+		return
+	}
+	logger.Warn(
+		fmt.Sprintf(
+			"multiple dingo processes found, none declared metrics-port=%d, picked lowest pid=%d",
+			port,
+			selected.proc.Pid,
+		),
+		"metrics-port",
+		port,
+		"picked-pid",
+		selected.proc.Pid,
+		"candidates",
+		formatDingoCandidates(candidates),
+	)
+}
+
+func formatDingoCandidates(candidates []dingoCandidate) string {
+	parts := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		parts = append(
+			parts,
+			fmt.Sprintf(
+				"pid=%d metrics-port=%s data-dir=%s",
+				candidate.proc.Pid,
+				candidate.metricsPort,
+				candidate.dataDir,
+			),
+		)
+	}
+	return "[" + strings.Join(parts, "] [") + "]"
+}
+
+// findTCPSocketOwner returns the PID that owns the configured Prometheus TCP
+// listener, if the OS exposes that socket ownership information.
+func findTCPSocketOwner(
+	ctx context.Context,
+	host string,
+	port uint32,
+) (int32, error) {
+	connections, err := netutil.ConnectionsWithContext(ctx, "tcp")
+	if err != nil {
+		return 0, err
+	}
+	for _, conn := range connections {
+		if conn.Status != "LISTEN" || conn.Laddr.Port != port || conn.Pid <= 0 {
+			continue
+		}
+		if tcpListenAddrMatches(conn.Laddr.IP, host) {
+			return conn.Pid, nil
+		}
+	}
+	return 0, fmt.Errorf("no tcp listener found on %s:%d", host, port)
+}
+
+// tcpListenAddrMatches treats wildcard listener addresses as matching any
+// scrape host, while still supporting exact and parsed IP comparisons.
+func tcpListenAddrMatches(listenHost, scrapeHost string) bool {
+	listenIP := net.ParseIP(listenHost)
+	if listenIP != nil && listenIP.IsUnspecified() {
+		return true
+	}
+	if listenHost == scrapeHost {
+		return true
+	}
+	scrapeIP := net.ParseIP(scrapeHost)
+	if listenIP == nil || scrapeIP == nil {
+		if scrapeHost == "localhost" && listenIP != nil {
+			return listenIP.IsLoopback()
+		}
+		return false
+	}
+	return listenIP.Equal(scrapeIP)
+}
+
+func listProcessesByName(
+	ctx context.Context,
+	name string,
+) ([]*process.Process, error) {
+	processes, err := process.ProcessesWithContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get processes: %w", err)
+	}
+	matches := []*process.Process{}
+	for _, proc := range processes {
+		procName, err := proc.NameWithContext(ctx)
+		if err != nil {
+			continue
+		}
+		if strings.Contains(procName, name) {
+			matches = append(matches, proc)
+		}
+	}
+	return matches, nil
 }
 
 func getProcessMetricsByPid(

--- a/main.go
+++ b/main.go
@@ -1368,7 +1368,7 @@ func findDingoProcess(
 		)
 		if err == nil && pid > 0 {
 			proc, err := getProcessMetricsByPid(ctx, pid)
-			if err == nil {
+			if err == nil && processNameContains(ctx, proc, DINGO_BINARY) {
 				logDingoProcessSelection(proc.Pid, "socket-owner")
 				return proc, nil
 			}
@@ -1470,6 +1470,27 @@ func lowestPIDDingoCandidate(candidates []dingoCandidate) dingoCandidate {
 		}
 	}
 	return selected
+}
+
+func processNameContains(
+	ctx context.Context,
+	proc *process.Process,
+	name string,
+) bool {
+	if procName, err := proc.NameWithContext(ctx); err == nil &&
+		strings.Contains(procName, name) {
+		return true
+	}
+	args, err := proc.CmdlineSliceWithContext(ctx)
+	if err != nil {
+		return false
+	}
+	for _, arg := range args {
+		if strings.Contains(arg, name) {
+			return true
+		}
+	}
+	return false
 }
 
 func valueFromArgs(args []string, flag string) string {

--- a/main.go
+++ b/main.go
@@ -124,6 +124,7 @@ func (h *bufferHandler) WithGroup(name string) slog.Handler {
 var (
 	logger                      *slog.Logger
 	dingoProcessSelectionLogged atomic.Bool
+	dingoProcessAmbiguityLogged atomic.Bool
 )
 
 // Global command line flags
@@ -1515,6 +1516,9 @@ func logMultipleDingoCandidates(
 	port uint32,
 ) {
 	if logger == nil {
+		return
+	}
+	if !dingoProcessAmbiguityLogged.CompareAndSwap(false, true) {
 		return
 	}
 	logger.Warn(

--- a/main.go
+++ b/main.go
@@ -1387,11 +1387,14 @@ func findDingoProcess(
 			)
 			if len(portMatches) == 1 {
 				proc := portMatches[0].proc
-				logDingoProcessSelection(proc.Pid, "cmdline-match")
+				logDingoProcessSelection(proc.Pid, "port-match")
 				return proc, nil
 			}
 			if len(portMatches) > 1 {
-				selected := lowestPIDDingoCandidate(portMatches)
+				selected, ok := lowestPIDDingoCandidate(portMatches)
+				if !ok {
+					return nil, fmt.Errorf("no dingo process found")
+				}
 				logDingoCandidateAmbiguity(
 					fmt.Sprintf(
 						"multiple dingo processes declared metrics-port=%d, picked lowest pid=%d",
@@ -1402,13 +1405,16 @@ func findDingoProcess(
 					portMatches,
 					cfg.Prometheus.Port,
 				)
-				logDingoProcessSelection(selected.proc.Pid, "cmdline-match")
+				logDingoProcessSelection(selected.proc.Pid, "port-match")
 				return selected.proc, nil
 			}
 
 			// If no process declares the scrape port, use a deterministic
 			// name-only fallback and warn when there is real ambiguity.
-			selected := lowestPIDDingoCandidate(candidates)
+			selected, ok := lowestPIDDingoCandidate(candidates)
+			if !ok {
+				return nil, fmt.Errorf("no dingo process found")
+			}
 			if len(candidates) > 1 {
 				logDingoCandidateAmbiguity(
 					fmt.Sprintf(
@@ -1455,18 +1461,18 @@ func inspectDingoCandidates(
 			dataDir:     "-",
 		}
 
+		if env, err := proc.EnvironWithContext(ctx); err == nil {
+			if metricsPort := valueFromEnv(env, "DINGO_METRICS_PORT"); metricsPort != "" {
+				candidate.metricsPort = metricsPort
+			}
+		}
+
 		if args, err := proc.CmdlineSliceWithContext(ctx); err == nil {
 			if metricsPort := valueFromArgs(args, "--metrics-port"); metricsPort != "" {
 				candidate.metricsPort = metricsPort
 			}
 			if dataDir := valueFromArgs(args, "--data-dir"); dataDir != "" {
 				candidate.dataDir = dataDir
-			}
-		}
-
-		if env, err := proc.EnvironWithContext(ctx); err == nil {
-			if metricsPort := valueFromEnv(env, "DINGO_METRICS_PORT"); metricsPort != "" {
-				candidate.metricsPort = metricsPort
 			}
 		}
 
@@ -1489,14 +1495,17 @@ func dingoCandidatesByMetricsPort(
 	return matches
 }
 
-func lowestPIDDingoCandidate(candidates []dingoCandidate) dingoCandidate {
+func lowestPIDDingoCandidate(candidates []dingoCandidate) (dingoCandidate, bool) {
+	if len(candidates) == 0 {
+		return dingoCandidate{}, false
+	}
 	selected := candidates[0]
 	for _, candidate := range candidates[1:] {
 		if candidate.proc.Pid < selected.proc.Pid {
 			selected = candidate
 		}
 	}
-	return selected
+	return selected, true
 }
 
 func processNameContains(
@@ -1620,7 +1629,9 @@ func findTCPSocketOwner(
 }
 
 // tcpListenAddrMatches treats wildcard listener addresses as matching any
-// scrape host, while still supporting exact and parsed IP comparisons.
+// scrape host, while still supporting exact and parsed IP comparisons. It does
+// not resolve arbitrary hostnames; gopsutil normally reports listener addresses
+// as IP literals.
 func tcpListenAddrMatches(listenHost, scrapeHost string) bool {
 	listenIP := net.ParseIP(listenHost)
 	if listenIP != nil && listenIP.IsUnspecified() {

--- a/main.go
+++ b/main.go
@@ -1531,15 +1531,15 @@ func processNameContains(
 }
 
 func valueFromArgs(args []string, flag string) string {
+	result := ""
 	for i, arg := range args {
 		if arg == flag && i+1 < len(args) {
-			return args[i+1]
-		}
-		if strings.HasPrefix(arg, flag+"=") {
-			return strings.TrimPrefix(arg, flag+"=")
+			result = args[i+1]
+		} else if strings.HasPrefix(arg, flag+"=") {
+			result = strings.TrimPrefix(arg, flag+"=")
 		}
 	}
-	return ""
+	return result
 }
 
 func valueFromEnv(env []string, name string) string {

--- a/main.go
+++ b/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -122,8 +121,10 @@ func (h *bufferHandler) WithGroup(name string) slog.Handler {
 	return &bufferHandler{handler: h.handler.WithGroup(name)}
 }
 
-var logger *slog.Logger
-var dingoProcessSelectionLogged atomic.Bool
+var (
+	logger                      *slog.Logger
+	dingoProcessSelectionLogged atomic.Bool
+)
 
 // Global command line flags
 var cmdlineFlags struct {
@@ -1677,47 +1678,6 @@ func getProcessMetricsByPidFile(
 	}
 
 	return proc, nil
-}
-
-func getProcessMetricsByName(
-	ctx context.Context,
-	_ *config.Config,
-) (*process.Process, error) {
-	r, _ := process.NewProcessWithContext(ctx, 0)
-	processes, err := process.ProcessesWithContext(ctx)
-	if err != nil {
-		return r, fmt.Errorf("failed to get processes: %w", err)
-	}
-	for _, p := range processes {
-		n, err := p.NameWithContext(ctx)
-		if err != nil {
-			continue
-		}
-
-		if strings.Contains(n, getEffectiveNodeBinary()) {
-			r = p
-			break
-		}
-	}
-
-	// Check if we found a process
-	if r == nil || r.Pid == 0 {
-		return r, fmt.Errorf(
-			"no process found with name containing %s",
-			getEffectiveNodeBinary(),
-		)
-	}
-
-	exists, err := r.IsRunning()
-	if err != nil {
-		return r, fmt.Errorf("failed to check if process is running: %w", err)
-	}
-
-	if !exists {
-		return r, errors.New("process is not running")
-	}
-
-	return r, nil
 }
 
 func getProcessMetricsByNameAndPort(

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -1393,7 +1394,7 @@ func findDingoProcess(
 			if len(portMatches) > 1 {
 				selected, ok := lowestPIDDingoCandidate(portMatches)
 				if !ok {
-					return nil, fmt.Errorf("no dingo process found")
+					return nil, errors.New("no dingo process found")
 				}
 				logDingoCandidateAmbiguity(
 					fmt.Sprintf(

--- a/main.go
+++ b/main.go
@@ -1359,8 +1359,8 @@ func findDingoProcess(
 		return proc, err
 	}
 
-	// Prefer the process that owns the Prometheus scrape socket. This is the
-	// strongest automatic signal because it is serving the metrics we read.
+	// First try the process listening on the Prometheus metrics port, because
+	// that is the process nview is reading metrics from.
 	if lookups.socketOwner != nil {
 		pid, err := lookups.socketOwner(
 			ctx,
@@ -1433,8 +1433,8 @@ func findDingoProcess(
 		}
 	}
 
-	// Last resort for single-process containers where Dingo is PID 1 but
-	// process enumeration did not find it.
+	// As a final fallback, try PID 1 for containers where Dingo is the only
+	// process but process listing did not find it.
 	proc, err := getProcessMetricsByPid(ctx, 1)
 	if err == nil {
 		logDingoProcessSelection(proc.Pid, "pid-1-fallback")

--- a/main_test.go
+++ b/main_test.go
@@ -121,6 +121,7 @@ func TestFindDingoProcessUsesSocketOwnerBeforePID1Fallback(t *testing.T) {
 	originalDetectedBinary, _ := detectedNodeBinary.Load().(string)
 	originalLogger := logger
 	originalSelectionLogged := dingoProcessSelectionLogged.Load()
+	originalAmbiguityLogged := dingoProcessAmbiguityLogged.Load()
 	defer func() {
 		cfg.Node.Binary = originalNodeBinary
 		cfg.Node.Pid = originalNodePid
@@ -130,6 +131,7 @@ func TestFindDingoProcessUsesSocketOwnerBeforePID1Fallback(t *testing.T) {
 		detectedNodeBinary.Store(originalDetectedBinary)
 		logger = originalLogger
 		dingoProcessSelectionLogged.Store(originalSelectionLogged)
+		dingoProcessAmbiguityLogged.Store(originalAmbiguityLogged)
 		logMutex.Lock()
 		logBuffer = nil
 		logMutex.Unlock()
@@ -142,6 +144,7 @@ func TestFindDingoProcessUsesSocketOwnerBeforePID1Fallback(t *testing.T) {
 	cfg.App.LogBufferSize = 10
 	detectedNodeBinary.Store(DINGO_BINARY)
 	dingoProcessSelectionLogged.Store(false)
+	dingoProcessAmbiguityLogged.Store(false)
 	logger = slog.New(&bufferHandler{
 		handler: slog.NewTextHandler(&strings.Builder{}, &slog.HandlerOptions{}),
 	})
@@ -269,12 +272,14 @@ func TestFindDingoProcessWarnsAndPicksLowestPIDForAmbiguousMultiMatch(t *testing
 	originalLogBufferSize := cfg.App.LogBufferSize
 	originalLogger := logger
 	originalSelectionLogged := dingoProcessSelectionLogged.Load()
+	originalAmbiguityLogged := dingoProcessAmbiguityLogged.Load()
 	defer func() {
 		cfg.Node.Pid = originalNodePid
 		cfg.Prometheus.Port = originalPromPort
 		cfg.App.LogBufferSize = originalLogBufferSize
 		logger = originalLogger
 		dingoProcessSelectionLogged.Store(originalSelectionLogged)
+		dingoProcessAmbiguityLogged.Store(originalAmbiguityLogged)
 		logMutex.Lock()
 		logBuffer = nil
 		logMutex.Unlock()
@@ -284,6 +289,7 @@ func TestFindDingoProcessWarnsAndPicksLowestPIDForAmbiguousMultiMatch(t *testing
 	cfg.Prometheus.Port = 12798
 	cfg.App.LogBufferSize = 10
 	dingoProcessSelectionLogged.Store(false)
+	dingoProcessAmbiguityLogged.Store(false)
 	logger = slog.New(&bufferHandler{
 		handler: slog.NewTextHandler(&strings.Builder{}, &slog.HandlerOptions{}),
 	})

--- a/main_test.go
+++ b/main_test.go
@@ -98,9 +98,21 @@ func startNamedDingoProcessHelper(
 	return nil
 }
 
+func preserveDingoDiscoveryAtomics(t *testing.T) {
+	t.Helper()
+	originalSelectionLogged := dingoProcessSelectionLogged.Load()
+	originalAmbiguityLogged := dingoProcessAmbiguityLogged.Load()
+	t.Cleanup(func() {
+		dingoProcessSelectionLogged.Store(originalSelectionLogged)
+		dingoProcessAmbiguityLogged.Store(originalAmbiguityLogged)
+	})
+}
+
 // TestFindDingoProcessUsesExplicitPID verifies that an operator-provided PID
 // wins before any automatic discovery is attempted.
 func TestFindDingoProcessUsesExplicitPID(t *testing.T) {
+	preserveDingoDiscoveryAtomics(t)
+
 	cfg := config.GetConfig()
 	originalNodePid := cfg.Node.Pid
 	defer func() {
@@ -212,6 +224,8 @@ func TestFindDingoProcessUsesSocketOwnerBeforePID1Fallback(t *testing.T) {
 // TestFindDingoProcessFallsBackFromSocketErrorToCmdlineMatch verifies that
 // socket lookup failures fall through to --metrics-port matching.
 func TestFindDingoProcessFallsBackFromSocketErrorToCmdlineMatch(t *testing.T) {
+	preserveDingoDiscoveryAtomics(t)
+
 	cfg := config.GetConfig()
 	originalNodePid := cfg.Node.Pid
 	originalPromPort := cfg.Prometheus.Port
@@ -224,7 +238,7 @@ func TestFindDingoProcessFallsBackFromSocketErrorToCmdlineMatch(t *testing.T) {
 	cfg.Prometheus.Port = 12798
 	matchingProc := startDingoProcessHelper(
 		t,
-		nil,
+		[]string{"DINGO_METRICS_PORT=12799"},
 		"--metrics-port=12798",
 		"--data-dir=/tmp/dingo-mainnet",
 	)
@@ -336,6 +350,8 @@ func TestFindDingoProcessWarnsAndPicksLowestPIDForDuplicateCmdlineMatches(t *tes
 // TestFindDingoProcessUsesEnvMetricsPortMatch verifies that
 // DINGO_METRICS_PORT can identify the process serving the scrape port.
 func TestFindDingoProcessUsesEnvMetricsPortMatch(t *testing.T) {
+	preserveDingoDiscoveryAtomics(t)
+
 	cfg := config.GetConfig()
 	originalNodePid := cfg.Node.Pid
 	originalPromPort := cfg.Prometheus.Port
@@ -352,13 +368,19 @@ func TestFindDingoProcessUsesEnvMetricsPortMatch(t *testing.T) {
 		"--data-dir",
 		"/tmp/dingo-mainnet",
 	)
+	nonmatchingProc := startDingoProcessHelper(
+		t,
+		[]string{"DINGO_METRICS_PORT=12799"},
+		"--data-dir",
+		"/tmp/dingo-preprod",
+	)
 
 	proc, err := findDingoProcess(context.Background(), cfg, procLookups{
 		socketOwner: func(context.Context, string, uint32) (int32, error) {
 			return 0, errors.New("no socket owner")
 		},
 		listProcs: func(context.Context, string) ([]*process.Process, error) {
-			return []*process.Process{matchingProc}, nil
+			return []*process.Process{nonmatchingProc, matchingProc}, nil
 		},
 	})
 	if err != nil {
@@ -403,6 +425,8 @@ func TestFindDingoProcessWarnsAndPicksLowestPIDForAmbiguousMultiMatch(t *testing
 	logBuffer = nil
 	logMutex.Unlock()
 
+	// Synthetic processes intentionally make cmdline/env reads fail, leaving
+	// candidate metadata as "-" to exercise the unreadable-process path.
 	lowest := &process.Process{Pid: 12345}
 	highest := &process.Process{Pid: 23456}
 	proc, err := findDingoProcess(context.Background(), cfg, procLookups{
@@ -442,6 +466,8 @@ func TestFindDingoProcessWarnsAndPicksLowestPIDForAmbiguousMultiMatch(t *testing
 // TestFindDingoProcessUsesSingleNameMatchWhenCmdlineUnreadable verifies that a
 // lone Dingo process is used even when cmdline and env metadata cannot be read.
 func TestFindDingoProcessUsesSingleNameMatchWhenCmdlineUnreadable(t *testing.T) {
+	preserveDingoDiscoveryAtomics(t)
+
 	cfg := config.GetConfig()
 	originalNodePid := cfg.Node.Pid
 	defer func() {
@@ -469,6 +495,8 @@ func TestFindDingoProcessUsesSingleNameMatchWhenCmdlineUnreadable(t *testing.T) 
 // TestFindDingoProcessFallsBackToPID1WhenNoNameMatches verifies that PID 1 is
 // only used after automatic discovery finds no Dingo process by name.
 func TestFindDingoProcessFallsBackToPID1WhenNoNameMatches(t *testing.T) {
+	preserveDingoDiscoveryAtomics(t)
+
 	cfg := config.GetConfig()
 	originalNodePid := cfg.Node.Pid
 	defer func() {

--- a/main_test.go
+++ b/main_test.go
@@ -228,13 +228,19 @@ func TestFindDingoProcessFallsBackFromSocketErrorToCmdlineMatch(t *testing.T) {
 		"--metrics-port=12798",
 		"--data-dir=/tmp/dingo-mainnet",
 	)
+	nonmatchingProc := startDingoProcessHelper(
+		t,
+		nil,
+		"--metrics-port=12799",
+		"--data-dir=/tmp/dingo-preprod",
+	)
 
 	proc, err := findDingoProcess(context.Background(), cfg, procLookups{
 		socketOwner: func(context.Context, string, uint32) (int32, error) {
 			return 0, errors.New("permission denied")
 		},
 		listProcs: func(context.Context, string) ([]*process.Process, error) {
-			return []*process.Process{matchingProc}, nil
+			return []*process.Process{nonmatchingProc, matchingProc}, nil
 		},
 	})
 	if err != nil {
@@ -242,6 +248,88 @@ func TestFindDingoProcessFallsBackFromSocketErrorToCmdlineMatch(t *testing.T) {
 	}
 	if proc.Pid != matchingProc.Pid {
 		t.Fatalf("findDingoProcess() returned pid %d, expected cmdline match pid %d", proc.Pid, matchingProc.Pid)
+	}
+}
+
+// TestFindDingoProcessWarnsAndPicksLowestPIDForDuplicateCmdlineMatches
+// verifies duplicate --metrics-port matches are treated as ambiguous.
+func TestFindDingoProcessWarnsAndPicksLowestPIDForDuplicateCmdlineMatches(t *testing.T) {
+	cfg := config.GetConfig()
+	originalNodePid := cfg.Node.Pid
+	originalPromPort := cfg.Prometheus.Port
+	originalLogBufferSize := cfg.App.LogBufferSize
+	originalLogger := logger
+	originalSelectionLogged := dingoProcessSelectionLogged.Load()
+	originalAmbiguityLogged := dingoProcessAmbiguityLogged.Load()
+	defer func() {
+		cfg.Node.Pid = originalNodePid
+		cfg.Prometheus.Port = originalPromPort
+		cfg.App.LogBufferSize = originalLogBufferSize
+		logger = originalLogger
+		dingoProcessSelectionLogged.Store(originalSelectionLogged)
+		dingoProcessAmbiguityLogged.Store(originalAmbiguityLogged)
+		logMutex.Lock()
+		logBuffer = nil
+		logMutex.Unlock()
+	}()
+
+	cfg.Node.Pid = 0
+	cfg.Prometheus.Port = 12798
+	cfg.App.LogBufferSize = 10
+	dingoProcessSelectionLogged.Store(false)
+	dingoProcessAmbiguityLogged.Store(false)
+	logger = slog.New(&bufferHandler{
+		handler: slog.NewTextHandler(&strings.Builder{}, &slog.HandlerOptions{}),
+	})
+	logMutex.Lock()
+	logBuffer = nil
+	logMutex.Unlock()
+
+	firstProc := startDingoProcessHelper(
+		t,
+		nil,
+		"--metrics-port=12798",
+		"--data-dir=/tmp/dingo-mainnet",
+	)
+	secondProc := startDingoProcessHelper(
+		t,
+		nil,
+		"--metrics-port=12798",
+		"--data-dir=/tmp/dingo-preprod",
+	)
+	expectedPID := firstProc.Pid
+	if secondProc.Pid < expectedPID {
+		expectedPID = secondProc.Pid
+	}
+
+	proc, err := findDingoProcess(context.Background(), cfg, procLookups{
+		socketOwner: func(context.Context, string, uint32) (int32, error) {
+			return 0, errors.New("permission denied")
+		},
+		listProcs: func(context.Context, string) ([]*process.Process, error) {
+			return []*process.Process{secondProc, firstProc}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("findDingoProcess() returned error: %v", err)
+	}
+	if proc.Pid != expectedPID {
+		t.Fatalf("findDingoProcess() returned pid %d, expected lowest duplicate match pid %d", proc.Pid, expectedPID)
+	}
+
+	logMutex.Lock()
+	defer logMutex.Unlock()
+	joinedLogs := strings.Join(logBuffer, "")
+	for _, expected := range []string{
+		"WARN",
+		"multiple dingo processes declared metrics-port=12798",
+		"picked-pid=",
+		"pid=",
+		"metrics-port=12798",
+	} {
+		if !strings.Contains(joinedLogs, expected) {
+			t.Fatalf("expected log buffer to contain %q, got %q", expected, joinedLogs)
+		}
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -67,7 +67,7 @@ func startNamedDingoProcessHelper(
 	if name != "" {
 		linkPath := filepath.Join(t.TempDir(), name)
 		if err := os.Symlink(executable, linkPath); err != nil {
-			t.Fatalf("failed to create helper symlink: %v", err)
+			t.Skipf("cannot create helper symlink: %v", err)
 		}
 		executable = linkPath
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -39,6 +39,8 @@ func TestDingoProcessHelper(t *testing.T) {
 	os.Exit(0)
 }
 
+// startDingoProcessHelper starts a real child process with optional env and
+// args so gopsutil can inspect cmdline/env data in tests.
 func startDingoProcessHelper(
 	t *testing.T,
 	env []string,
@@ -48,6 +50,8 @@ func startDingoProcessHelper(
 	return startNamedDingoProcessHelper(t, "", env, args...)
 }
 
+// startNamedDingoProcessHelper starts the helper through an optional symlink
+// name so socket-owner tests can make the process look like Dingo.
 func startNamedDingoProcessHelper(
 	t *testing.T,
 	name string,
@@ -98,6 +102,8 @@ func startNamedDingoProcessHelper(
 	return nil
 }
 
+// preserveDingoDiscoveryAtomics restores one-shot Dingo logging flags so tests
+// that invoke findDingoProcess do not leak state into later tests.
 func preserveDingoDiscoveryAtomics(t *testing.T) {
 	t.Helper()
 	originalSelectionLogged := dingoProcessSelectionLogged.Load()

--- a/main_test.go
+++ b/main_test.go
@@ -118,7 +118,7 @@ func TestFindDingoProcessUsesSocketOwnerBeforePID1Fallback(t *testing.T) {
 	originalPromHost := cfg.Prometheus.Host
 	originalPromPort := cfg.Prometheus.Port
 	originalLogBufferSize := cfg.App.LogBufferSize
-	originalDetectedBinary := getEffectiveNodeBinary()
+	originalDetectedBinary, _ := detectedNodeBinary.Load().(string)
 	originalLogger := logger
 	originalSelectionLogged := dingoProcessSelectionLogged.Load()
 	defer func() {

--- a/main_test.go
+++ b/main_test.go
@@ -16,13 +16,365 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log/slog"
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/blinklabs-io/nview/internal/config"
+	"github.com/shirou/gopsutil/v3/process"
 )
+
+// TestDingoProcessHelper is a subprocess target used by tests that need a real
+// process with readable cmdline and environment metadata.
+func TestDingoProcessHelper(t *testing.T) {
+	if os.Getenv("GO_WANT_DINGO_PROCESS_HELPER") != "1" {
+		return
+	}
+	time.Sleep(time.Minute)
+	os.Exit(0)
+}
+
+func startDingoProcessHelper(
+	t *testing.T,
+	env []string,
+	args ...string,
+) *process.Process {
+	t.Helper()
+
+	cmdArgs := append([]string{"-test.run=TestDingoProcessHelper", "--"}, args...)
+	cmd := exec.Command(os.Args[0], cmdArgs...)
+	cmd.Env = append(os.Environ(), "GO_WANT_DINGO_PROCESS_HELPER=1")
+	cmd.Env = append(cmd.Env, env...)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start helper process: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+
+	proc, err := process.NewProcessWithContext(
+		context.Background(),
+		int32(cmd.Process.Pid),
+	)
+	if err != nil {
+		t.Fatalf("failed to inspect helper process: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := proc.CmdlineSliceWithContext(context.Background()); err == nil {
+			return proc
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("helper process cmdline was not readable")
+	return nil
+}
+
+// TestFindDingoProcessUsesExplicitPID verifies that an operator-provided PID
+// wins before any automatic discovery is attempted.
+func TestFindDingoProcessUsesExplicitPID(t *testing.T) {
+	cfg := config.GetConfig()
+	originalNodePid := cfg.Node.Pid
+	defer func() {
+		cfg.Node.Pid = originalNodePid
+	}()
+
+	cfg.Node.Pid = int32(os.Getpid())
+
+	proc, err := findDingoProcess(context.Background(), cfg, procLookups{
+		socketOwner: func(context.Context, string, uint32) (int32, error) {
+			t.Fatal("socketOwner should not be called when explicit PID is set")
+			return 0, nil
+		},
+		listProcs: func(context.Context, string) ([]*process.Process, error) {
+			t.Fatal("listProcs should not be called when explicit PID is set")
+			return nil, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("findDingoProcess() returned error: %v", err)
+	}
+	if proc.Pid != cfg.Node.Pid {
+		t.Fatalf("findDingoProcess() returned pid %d, expected %d", proc.Pid, cfg.Node.Pid)
+	}
+}
+
+// TestFindDingoProcessUsesSocketOwnerBeforePID1Fallback verifies that the
+// process serving the Prometheus scrape socket wins over the PID 1 fallback.
+func TestFindDingoProcessUsesSocketOwnerBeforePID1Fallback(t *testing.T) {
+	cfg := config.GetConfig()
+	originalNodeBinary := cfg.Node.Binary
+	originalNodePid := cfg.Node.Pid
+	originalPromHost := cfg.Prometheus.Host
+	originalPromPort := cfg.Prometheus.Port
+	originalLogBufferSize := cfg.App.LogBufferSize
+	originalDetectedBinary := getEffectiveNodeBinary()
+	originalLogger := logger
+	originalSelectionLogged := dingoProcessSelectionLogged.Load()
+	defer func() {
+		cfg.Node.Binary = originalNodeBinary
+		cfg.Node.Pid = originalNodePid
+		cfg.Prometheus.Host = originalPromHost
+		cfg.Prometheus.Port = originalPromPort
+		cfg.App.LogBufferSize = originalLogBufferSize
+		detectedNodeBinary.Store(originalDetectedBinary)
+		logger = originalLogger
+		dingoProcessSelectionLogged.Store(originalSelectionLogged)
+		logMutex.Lock()
+		logBuffer = nil
+		logMutex.Unlock()
+	}()
+
+	cfg.Node.Binary = DINGO_BINARY
+	cfg.Node.Pid = 0
+	cfg.Prometheus.Host = "127.0.0.1"
+	cfg.Prometheus.Port = 12798
+	cfg.App.LogBufferSize = 10
+	detectedNodeBinary.Store(DINGO_BINARY)
+	dingoProcessSelectionLogged.Store(false)
+	logger = slog.New(&bufferHandler{
+		handler: slog.NewTextHandler(&strings.Builder{}, &slog.HandlerOptions{}),
+	})
+	logMutex.Lock()
+	logBuffer = nil
+	logMutex.Unlock()
+
+	socketOwnerPID := int32(os.Getpid())
+	proc, err := findDingoProcess(context.Background(), cfg, procLookups{
+		socketOwner: func(
+			_ context.Context,
+			host string,
+			port uint32,
+		) (int32, error) {
+			if host != cfg.Prometheus.Host {
+				t.Fatalf("socketOwner host = %q, expected %q", host, cfg.Prometheus.Host)
+			}
+			if port != cfg.Prometheus.Port {
+				t.Fatalf("socketOwner port = %d, expected %d", port, cfg.Prometheus.Port)
+			}
+			return socketOwnerPID, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("findDingoProcess() returned error: %v", err)
+	}
+
+	if proc.Pid != socketOwnerPID {
+		t.Fatalf("findDingoProcess() returned pid %d, expected socket owner pid %d", proc.Pid, socketOwnerPID)
+	}
+
+	logMutex.Lock()
+	defer logMutex.Unlock()
+	joinedLogs := strings.Join(logBuffer, "")
+	for _, expected := range []string{
+		"INFO",
+		"selected dingo process",
+		"pid=",
+		"method=socket-owner",
+	} {
+		if !strings.Contains(joinedLogs, expected) {
+			t.Fatalf("expected log buffer to contain %q, got %q", expected, joinedLogs)
+		}
+	}
+}
+
+// TestFindDingoProcessFallsBackFromSocketErrorToCmdlineMatch verifies that
+// socket lookup failures fall through to --metrics-port matching.
+func TestFindDingoProcessFallsBackFromSocketErrorToCmdlineMatch(t *testing.T) {
+	cfg := config.GetConfig()
+	originalNodePid := cfg.Node.Pid
+	originalPromPort := cfg.Prometheus.Port
+	defer func() {
+		cfg.Node.Pid = originalNodePid
+		cfg.Prometheus.Port = originalPromPort
+	}()
+
+	cfg.Node.Pid = 0
+	cfg.Prometheus.Port = 12798
+	matchingProc := startDingoProcessHelper(
+		t,
+		nil,
+		"--metrics-port=12798",
+		"--data-dir=/tmp/dingo-mainnet",
+	)
+
+	proc, err := findDingoProcess(context.Background(), cfg, procLookups{
+		socketOwner: func(context.Context, string, uint32) (int32, error) {
+			return 0, errors.New("permission denied")
+		},
+		listProcs: func(context.Context, string) ([]*process.Process, error) {
+			return []*process.Process{matchingProc}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("findDingoProcess() returned error: %v", err)
+	}
+	if proc.Pid != matchingProc.Pid {
+		t.Fatalf("findDingoProcess() returned pid %d, expected cmdline match pid %d", proc.Pid, matchingProc.Pid)
+	}
+}
+
+// TestFindDingoProcessUsesEnvMetricsPortMatch verifies that
+// DINGO_METRICS_PORT can identify the process serving the scrape port.
+func TestFindDingoProcessUsesEnvMetricsPortMatch(t *testing.T) {
+	cfg := config.GetConfig()
+	originalNodePid := cfg.Node.Pid
+	originalPromPort := cfg.Prometheus.Port
+	defer func() {
+		cfg.Node.Pid = originalNodePid
+		cfg.Prometheus.Port = originalPromPort
+	}()
+
+	cfg.Node.Pid = 0
+	cfg.Prometheus.Port = 12798
+	matchingProc := startDingoProcessHelper(
+		t,
+		[]string{"DINGO_METRICS_PORT=12798"},
+		"--data-dir",
+		"/tmp/dingo-mainnet",
+	)
+
+	proc, err := findDingoProcess(context.Background(), cfg, procLookups{
+		socketOwner: func(context.Context, string, uint32) (int32, error) {
+			return 0, errors.New("no socket owner")
+		},
+		listProcs: func(context.Context, string) ([]*process.Process, error) {
+			return []*process.Process{matchingProc}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("findDingoProcess() returned error: %v", err)
+	}
+	if proc.Pid != matchingProc.Pid {
+		t.Fatalf("findDingoProcess() returned pid %d, expected env match pid %d", proc.Pid, matchingProc.Pid)
+	}
+}
+
+// TestFindDingoProcessWarnsAndPicksLowestPIDForAmbiguousMultiMatch verifies
+// the deterministic fallback and visible warning for ambiguous multi-instance setups.
+func TestFindDingoProcessWarnsAndPicksLowestPIDForAmbiguousMultiMatch(t *testing.T) {
+	cfg := config.GetConfig()
+	originalNodePid := cfg.Node.Pid
+	originalPromPort := cfg.Prometheus.Port
+	originalLogBufferSize := cfg.App.LogBufferSize
+	originalLogger := logger
+	originalSelectionLogged := dingoProcessSelectionLogged.Load()
+	defer func() {
+		cfg.Node.Pid = originalNodePid
+		cfg.Prometheus.Port = originalPromPort
+		cfg.App.LogBufferSize = originalLogBufferSize
+		logger = originalLogger
+		dingoProcessSelectionLogged.Store(originalSelectionLogged)
+		logMutex.Lock()
+		logBuffer = nil
+		logMutex.Unlock()
+	}()
+
+	cfg.Node.Pid = 0
+	cfg.Prometheus.Port = 12798
+	cfg.App.LogBufferSize = 10
+	dingoProcessSelectionLogged.Store(false)
+	logger = slog.New(&bufferHandler{
+		handler: slog.NewTextHandler(&strings.Builder{}, &slog.HandlerOptions{}),
+	})
+	logMutex.Lock()
+	logBuffer = nil
+	logMutex.Unlock()
+
+	lowest := &process.Process{Pid: 12345}
+	highest := &process.Process{Pid: 23456}
+	proc, err := findDingoProcess(context.Background(), cfg, procLookups{
+		socketOwner: func(context.Context, string, uint32) (int32, error) {
+			return 0, errors.New("no socket owner")
+		},
+		listProcs: func(context.Context, string) ([]*process.Process, error) {
+			return []*process.Process{highest, lowest}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("findDingoProcess() returned error: %v", err)
+	}
+	if proc.Pid != lowest.Pid {
+		t.Fatalf("findDingoProcess() returned pid %d, expected lowest pid %d", proc.Pid, lowest.Pid)
+	}
+
+	logMutex.Lock()
+	defer logMutex.Unlock()
+	if len(logBuffer) == 0 {
+		t.Fatal("expected warning log entry in buffer")
+	}
+	joinedLogs := strings.Join(logBuffer, "")
+	for _, expected := range []string{
+		"WARN",
+		"multiple dingo processes found",
+		"picked-pid=12345",
+		"pid=12345 metrics-port=- data-dir=-",
+		"pid=23456 metrics-port=- data-dir=-",
+	} {
+		if !strings.Contains(joinedLogs, expected) {
+			t.Fatalf("expected log buffer to contain %q, got %q", expected, joinedLogs)
+		}
+	}
+}
+
+// TestFindDingoProcessUsesSingleNameMatchWhenCmdlineUnreadable verifies that a
+// lone Dingo process is used even when cmdline and env metadata cannot be read.
+func TestFindDingoProcessUsesSingleNameMatchWhenCmdlineUnreadable(t *testing.T) {
+	cfg := config.GetConfig()
+	originalNodePid := cfg.Node.Pid
+	defer func() {
+		cfg.Node.Pid = originalNodePid
+	}()
+
+	cfg.Node.Pid = 0
+	namedProc := &process.Process{Pid: 54321}
+	proc, err := findDingoProcess(context.Background(), cfg, procLookups{
+		socketOwner: func(context.Context, string, uint32) (int32, error) {
+			return 0, errors.New("no socket owner")
+		},
+		listProcs: func(context.Context, string) ([]*process.Process, error) {
+			return []*process.Process{namedProc}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("findDingoProcess() returned error: %v", err)
+	}
+	if proc.Pid != namedProc.Pid {
+		t.Fatalf("findDingoProcess() returned pid %d, expected single name match pid %d", proc.Pid, namedProc.Pid)
+	}
+}
+
+// TestFindDingoProcessFallsBackToPID1WhenNoNameMatches verifies that PID 1 is
+// only used after automatic discovery finds no Dingo process by name.
+func TestFindDingoProcessFallsBackToPID1WhenNoNameMatches(t *testing.T) {
+	cfg := config.GetConfig()
+	originalNodePid := cfg.Node.Pid
+	defer func() {
+		cfg.Node.Pid = originalNodePid
+	}()
+
+	cfg.Node.Pid = 0
+	proc, err := findDingoProcess(context.Background(), cfg, procLookups{
+		socketOwner: func(context.Context, string, uint32) (int32, error) {
+			return 0, errors.New("no socket owner")
+		},
+		listProcs: func(context.Context, string) ([]*process.Process, error) {
+			return nil, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("findDingoProcess() returned error: %v", err)
+	}
+	if proc.Pid != 1 {
+		t.Fatalf("findDingoProcess() returned pid %d, expected PID 1 fallback", proc.Pid)
+	}
+}
 
 func TestGetEpochProgress(t *testing.T) {
 	tests := []struct {

--- a/main_test.go
+++ b/main_test.go
@@ -45,8 +45,12 @@ func startDingoProcessHelper(
 ) *process.Process {
 	t.Helper()
 
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatalf("failed to find test executable: %v", err)
+	}
 	cmdArgs := append([]string{"-test.run=TestDingoProcessHelper", "--"}, args...)
-	cmd := exec.Command(os.Args[0], cmdArgs...)
+	cmd := exec.Command(executable, cmdArgs...)
 	cmd.Env = append(os.Environ(), "GO_WANT_DINGO_PROCESS_HELPER=1")
 	cmd.Env = append(cmd.Env, env...)
 	if err := cmd.Start(); err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -520,6 +520,51 @@ func TestFindDingoProcessFallsBackToPID1WhenNoNameMatches(t *testing.T) {
 	}
 }
 
+func TestValueFromArgsUsesLastFlagOccurrence(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "equals form",
+			args: []string{
+				"--metrics-port=12798",
+				"--metrics-port=12799",
+			},
+			want: "12799",
+		},
+		{
+			name: "separate value form",
+			args: []string{
+				"--metrics-port",
+				"12798",
+				"--metrics-port",
+				"12799",
+			},
+			want: "12799",
+		},
+		{
+			name: "mixed forms",
+			args: []string{
+				"--metrics-port=12798",
+				"--metrics-port",
+				"12799",
+			},
+			want: "12799",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := valueFromArgs(tt.args, "--metrics-port")
+			if got != tt.want {
+				t.Fatalf("valueFromArgs() = %q, expected %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetEpochProgress(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/main_test.go
+++ b/main_test.go
@@ -20,6 +20,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -44,10 +45,27 @@ func startDingoProcessHelper(
 	args ...string,
 ) *process.Process {
 	t.Helper()
+	return startNamedDingoProcessHelper(t, "", env, args...)
+}
+
+func startNamedDingoProcessHelper(
+	t *testing.T,
+	name string,
+	env []string,
+	args ...string,
+) *process.Process {
+	t.Helper()
 
 	executable, err := os.Executable()
 	if err != nil {
 		t.Fatalf("failed to find test executable: %v", err)
+	}
+	if name != "" {
+		linkPath := filepath.Join(t.TempDir(), name)
+		if err := os.Symlink(executable, linkPath); err != nil {
+			t.Fatalf("failed to create helper symlink: %v", err)
+		}
+		executable = linkPath
 	}
 	cmdArgs := append([]string{"-test.run=TestDingoProcessHelper", "--"}, args...)
 	cmd := exec.Command(executable, cmdArgs...)
@@ -152,7 +170,7 @@ func TestFindDingoProcessUsesSocketOwnerBeforePID1Fallback(t *testing.T) {
 	logBuffer = nil
 	logMutex.Unlock()
 
-	socketOwnerPID := int32(os.Getpid())
+	socketOwnerProc := startNamedDingoProcessHelper(t, DINGO_BINARY, nil)
 	proc, err := findDingoProcess(context.Background(), cfg, procLookups{
 		socketOwner: func(
 			_ context.Context,
@@ -165,15 +183,15 @@ func TestFindDingoProcessUsesSocketOwnerBeforePID1Fallback(t *testing.T) {
 			if port != cfg.Prometheus.Port {
 				t.Fatalf("socketOwner port = %d, expected %d", port, cfg.Prometheus.Port)
 			}
-			return socketOwnerPID, nil
+			return socketOwnerProc.Pid, nil
 		},
 	})
 	if err != nil {
 		t.Fatalf("findDingoProcess() returned error: %v", err)
 	}
 
-	if proc.Pid != socketOwnerPID {
-		t.Fatalf("findDingoProcess() returned pid %d, expected socket owner pid %d", proc.Pid, socketOwnerPID)
+	if proc.Pid != socketOwnerProc.Pid {
+		t.Fatalf("findDingoProcess() returned pid %d, expected socket owner pid %d", proc.Pid, socketOwnerProc.Pid)
 	}
 
 	logMutex.Lock()


### PR DESCRIPTION
1. Updated dingo process discovery so nview no longer defaults to pid 1 when `CARDANO_NODE_PID` is not set.
2. Added a dedicated findDingoProcess discovery chain.
3. Added injectable process lookups for easier unit testing and added socket-owner detection using gopsutil/v3/net.ConnectionsWithContext.
4. Added cmdline/env matching for --metrics-port=<port>, --metrics-port <port> and DINGO_METRICS_PORT=<port>.
5. Added deterministic fallback for ambiguous multiple dingo processes.
6. Added WARN logging when multiple dingo processes are found without a matching metrics port.
7. Added one-time INFO logging for the selected dingo process and selection method.
8. I have kept pid 1 only as the final fallback when no dingo process is found.
9. Added all the requried unit tests for the dingo discovery flow.

Closes #451 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Dingo process discovery to avoid defaulting to PID 1 and reliably pick the correct instance in containers and multi-instance setups, while logging selection and ambiguity only once. Closes #451.

- **Bug Fixes**
  - Added `findDingoProcess` chain: explicit PID → socket owner → port-match (CLI flags override env; last flag wins) → name-only lowest PID → PID 1.
  - Validate socket-owner PID is a Dingo process (checks name/cmdline).
  - Detect socket owner via `gopsutil/v3/net.ConnectionsWithContext`, handling wildcard and loopback addresses.
  - On duplicate port matches, warn once and pick the lowest PID deterministically.
  - One-shot logs: INFO for chosen PID and WARN once for ambiguous multi-instance cases.

- **Refactors**
  - Injected process lookups for testability; stabilized detected binary in tests and added unit tests for precedence, socket-owner, port/env matches, duplicate matches, name-only, PID 1 fallback, and last-flag-wins parsing.
  - Test helper now skips symlink-based naming when unsupported to avoid flaky runs.
  - Fixed lint and Nailway checks.

<sup>Written for commit 6adc2e6aea2ce4660c4f707a2897f15389e61a1d. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/nview/pull/454?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process discovery with multiple reliable fallbacks, deterministic selection when multiple candidates exist, and clearer one-time selection/ambiguity warnings to aid troubleshooting.
  * Better handling of socket/port and env-based matches to more consistently pick the correct target for metrics collection.

* **Tests**
  * Added comprehensive tests covering selection priority, socket and env matching, ambiguity handling, and PID fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/nview/pull/454?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->