### PR TITLE
chore: test and build on Go 1.26

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -16,7 +16,7 @@ jobs:
     name: go-test
     strategy:
       matrix:
-        go-version: [1.25.x]
+        go-version: [1.25.x, 1.26.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0 https://github.com/actions/setup-go/releases/tag/v6.0.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
           cache: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1 https://github.com/golangci/golangci-lint-action/releases/tag/v9.2.1

--- a/.github/workflows/nilaway.yml
+++ b/.github/workflows/nilaway.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3 https://github.com/actions/checkout/releases/tag/v6.0.3
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0 https://github.com/actions/setup-go/releases/tag/v6.0.0
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
           cache: true
       - name: install nilaway
         run: go install go.uber.org/nilaway/cmd/nilaway@latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,7 @@ jobs:
           fetch-depth: '0'
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6 https://github.com/actions/setup-go/releases/tag/v6
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
           cache: true
       - name: Update GeoCity2-Lite DB
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
## Summary

The module already requires Go 1.25 (`go 1.25.0`); this completes the org-wide Go upgrade by also exercising it on **1.26**, matching the rest of the Blink Labs Go repos:

- `go-test.yml`: matrix `[1.25.x]` → `[1.25.x, 1.26.x]`
- `golangci-lint.yml`, `nilaway.yml`, `publish.yml`: `1.25.x` → `1.26.x`

`go.mod` is unchanged (already at the 1.25 minimum).

## Verification

`go build ./...`, `go vet ./...`, `go test ./...`, `gofmt -l`, and `golangci-lint run ./...` (0 issues) all pass locally on Go 1.26.

Part of the org-wide Go 1.25 upgrade (blinklabs-io/issues#120).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update CI to verify the module on Go 1.26 while keeping 1.25 support. This aligns our tests, lint, and publish jobs with the org-wide Go upgrade.

- **Refactors**
  - go-test matrix runs on 1.25.x and 1.26.x
  - `golangci-lint`, `nilaway`, and publish workflows now use Go 1.26.x
  - No `go.mod` change; minimum remains 1.25

<sup>Written for commit 6d9b18243b9fcafdd41fd94b2e48e2ad1c73b39e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/nview/pull/470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

