### PR TITLE
fix: correct block propagation percentage

### DIFF
--- a/main.go
+++ b/main.go
@@ -1449,9 +1449,9 @@ func getBlockText(ctx context.Context) string {
 
 	var sb strings.Builder
 
-	blk1s := fmt.Sprintf("%.2f", promMetrics.BlocksW1s*100)
-	blk3s := fmt.Sprintf("%.2f", promMetrics.BlocksW3s*100)
-	blk5s := fmt.Sprintf("%.2f", promMetrics.BlocksW5s*100)
+	blk1s := formatBlockPropagationPercent(promMetrics.BlocksW1s)
+	blk3s := formatBlockPropagationPercent(promMetrics.BlocksW3s)
+	blk5s := formatBlockPropagationPercent(promMetrics.BlocksW5s)
 	delay := fmt.Sprintf("%.2f", promMetrics.BlockDelay)
 
 	// Row 1
@@ -1479,6 +1479,13 @@ func getBlockText(ctx context.Context) string {
 
 	failCount.Store(0)
 	return sb.String()
+}
+
+func formatBlockPropagationPercent(value float64) string {
+	if getEffectiveNodeBinary() != DINGO_BINARY && value <= 1 {
+		value *= 100
+	}
+	return fmt.Sprintf("%.2f", value)
 }
 
 func getNodeText(ctx context.Context) string {

--- a/main_test.go
+++ b/main_test.go
@@ -807,6 +807,65 @@ func TestFormatDingoRate(t *testing.T) {
 	}
 }
 
+func TestFormatBlockPropagationPercent(t *testing.T) {
+	cfg := config.GetConfig()
+	originalBinary := cfg.Node.Binary
+	originalDetectedBinary, _ := detectedNodeBinary.Load().(string)
+	defer func() {
+		cfg.Node.Binary = originalBinary
+		detectedNodeBinary.Store(originalDetectedBinary)
+	}()
+
+	tests := []struct {
+		name   string
+		binary string
+		value  float64
+		want   string
+	}{
+		{
+			name:   "cardano node ratio",
+			binary: CARDANO_BINARY,
+			value:  0.992083,
+			want:   "99.21",
+		},
+		{
+			name:   "cardano node percent",
+			binary: CARDANO_BINARY,
+			value:  99.2083,
+			want:   "99.21",
+		},
+		{
+			name:   "dingo percent",
+			binary: DINGO_BINARY,
+			value:  99.2083,
+			want:   "99.21",
+		},
+		{
+			name:   "dingo sub-one percent",
+			binary: DINGO_BINARY,
+			value:  0.5,
+			want:   "0.50",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg.Node.Binary = ""
+			detectedNodeBinary.Store(tt.binary)
+
+			got := formatBlockPropagationPercent(tt.value)
+			if got != tt.want {
+				t.Errorf(
+					"formatBlockPropagationPercent(%f) = %q, expected %q",
+					tt.value,
+					got,
+					tt.want,
+				)
+			}
+		})
+	}
+}
+
 // TestApplyDefaultSecondaryView verifies the first-scrape secondary pane
 // default and the NVIEW_DEFAULT_VIEW override behavior.
 func TestApplyDefaultSecondaryView(t *testing.T) {


### PR DESCRIPTION
Closes #460 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect block propagation percentages by normalizing metrics per node binary so 1s/3s/5s values display correctly whether the source reports ratios or percents.

- **Bug Fixes**
  - Replaced inline math in `getBlockText` with `formatBlockPropagationPercent` to multiply by 100 only for non-`DINGO_BINARY` values ≤ 1.
  - Added tests for `CARDANO_BINARY` (ratio and percent inputs) and `DINGO_BINARY` (percent and sub-one cases).

<sup>Written for commit c3fa28f04d3806380b3e4c53e6797b34796f979b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/nview/pull/473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block propagation percentage display for different node types, ensuring percentages are shown correctly instead of always being scaled the same way.
  * Fixed formatting for “Within 1s/3s/5s” values so the displayed numbers are more accurate and consistent.

* **Tests**
  * Added coverage for block propagation percentage formatting across multiple node formats and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->