### PR TITLE
fix: node version display

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -27,26 +27,31 @@ import (
 )
 
 func getNodeVersion() (version string, revision string, err error) {
-	cmd := exec.Command(getEffectiveNodeBinary(), "version") // #nosec G204
+	binary := getEffectiveNodeBinary()
+	cmd := exec.Command(binary, "version") // #nosec G204
 	stdout, err := cmd.Output()
 	if err != nil {
 		return "N/A", "N/A", fmt.Errorf(
 			"failed to execute %s version command: %w",
-			getEffectiveNodeBinary(),
+			binary,
 			err,
 		)
 	}
-	output := strings.TrimSpace(string(stdout))
+	return parseNodeVersionOutput(binary, strings.TrimSpace(string(stdout)))
+}
 
+func parseNodeVersionOutput(
+	binary string,
+	output string,
+) (version string, revision string, err error) {
 	// Handle Dingo format: "devel (commit 80ae952)" or "v0.17.0 (commit 1f54020)"
-	if strings.Contains(output, "(commit ") {
-		parts := strings.Split(output, " ")
-		if len(parts) >= 3 {
-			version = parts[0]
-			// Extract commit hash from "(commit XXXXXXX)"
-			commitPart := parts[2]
-			if strings.HasPrefix(commitPart, "(commit") && len(commitPart) > 7 {
-				revision = commitPart[7 : len(commitPart)-1] // Remove "(commit" and ")"
+	if commitStart := strings.Index(output, "(commit "); commitStart >= 0 {
+		version = strings.TrimSpace(output[:commitStart])
+		hashStart := commitStart + len("(commit ")
+		hashEnd := strings.Index(output[hashStart:], ")")
+		if version != "" && hashEnd >= 0 {
+			revision = strings.TrimSpace(output[hashStart : hashStart+hashEnd])
+			if revision != "" {
 				if len(revision) > 8 {
 					revision = revision[0:8]
 				}
@@ -56,16 +61,27 @@ func getNodeVersion() (version string, revision string, err error) {
 	}
 
 	// Handle cardano-node format (fallback)
-	strArray := strings.Split(output, " ")
-	if len(strArray) < 8 {
+	strArray := strings.Fields(output)
+	if len(strArray) < 2 {
 		return "N/A", "N/A", fmt.Errorf(
-			"unexpected version format from %s: output has %d parts, expected at least 8",
-			getEffectiveNodeBinary(),
+			"unexpected version format from %s: output has %d parts, expected at least 2",
+			binary,
 			len(strArray),
 		)
 	}
 	version = strArray[1]
-	revision = strArray[7]
+	for idx, part := range strArray {
+		if part == "rev" && idx+1 < len(strArray) {
+			revision = strArray[idx+1]
+			break
+		}
+	}
+	if revision == "" {
+		return "N/A", "N/A", fmt.Errorf(
+			"unexpected version format from %s: output is missing git revision",
+			binary,
+		)
+	}
 	if len(revision) > 8 {
 		revision = revision[0:8]
 	}

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,88 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "testing"
+
+func TestParseNodeVersionOutput(t *testing.T) {
+	tests := []struct {
+		name         string
+		binary       string
+		output       string
+		wantVersion  string
+		wantRevision string
+		wantErr      bool
+	}{
+		{
+			name:         "dingo devel",
+			binary:       DINGO_BINARY,
+			output:       "devel (commit 80ae952)",
+			wantVersion:  "devel",
+			wantRevision: "80ae952",
+		},
+		{
+			name:         "dingo release truncates commit",
+			binary:       DINGO_BINARY,
+			output:       "v0.17.0 (commit 1f54020abcdef)",
+			wantVersion:  "v0.17.0",
+			wantRevision: "1f54020a",
+		},
+		{
+			name:         "cardano node multiline",
+			binary:       CARDANO_BINARY,
+			output:       "cardano-node 10.5.1 - linux-x86_64 - ghc-9.6.7\ngit rev 1234567890abcdef",
+			wantVersion:  "10.5.1",
+			wantRevision: "12345678",
+		},
+		{
+			name:    "invalid output",
+			binary:  DINGO_BINARY,
+			output:  "unexpected",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotVersion, gotRevision, err := parseNodeVersionOutput(
+				tt.binary,
+				tt.output,
+			)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("parseNodeVersionOutput() error = nil, expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseNodeVersionOutput() error = %v", err)
+			}
+			if gotVersion != tt.wantVersion {
+				t.Errorf(
+					"parseNodeVersionOutput() version = %q, expected %q",
+					gotVersion,
+					tt.wantVersion,
+				)
+			}
+			if gotRevision != tt.wantRevision {
+				t.Errorf(
+					"parseNodeVersionOutput() revision = %q, expected %q",
+					gotRevision,
+					tt.wantRevision,
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes node version display by parsing both Dingo and cardano-node outputs and showing the correct version with an 8-char git revision.

- **Bug Fixes**
  - Support Dingo "(commit ...)" and multi-line cardano-node "git rev" outputs.
  - Error clearly when revision is missing or format is invalid.
  - Add tests for Dingo, cardano-node, truncation, and invalid input.

- **Refactors**
  - Extract parsing into parseNodeVersionOutput for reuse and testing.
  - Use fields-based parsing and search for "rev"; include the active binary in error messages.

<sup>Written for commit 749b9c7246a20dbc7ff0f18b3d40ea0bf89e06e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/nview/pull/474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

