### PR TITLE
feat: musashi named network

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -11,7 +11,7 @@ app:
   # Named Cardano network for the node
   #
   # This is a short-cut to select the NetworkMagic and can be used to
-  # select mainnet, preprod, preview, or sancho networks.
+  # select mainnet, preprod, preview, musashi, or sancho networks.
   #
   # This can also be set via the NETWORK environment variable and overrides
   # the node specific setting below
@@ -31,7 +31,7 @@ node:
   # Named Cardano network for the node
   #
   # This is a short-cut to select the NetworkMagic and can be used to
-  # select mainnet, preprod, preview, or sancho networks.
+  # select mainnet, preprod, preview, musashi, or sancho networks.
   #
   # This can also be set via the CARDANO_NETWORK environment variable
   network: mainnet

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -390,7 +390,7 @@ func (c *Config) populateShelleyGenesis() error {
 	}
 
 	if c.Node.ShelleyGenesis.EpochLength == 0 {
-		// Our epoch length is 432000, except sanchonet/preview/musashi
+		// Our epoch length is 432000, except sancho/preview/musashi
 		c.Node.ShelleyGenesis.EpochLength = 432000
 		switch network {
 		case "sancho", "preview", "musashi":

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -250,6 +250,8 @@ func (c *Config) populateNetworkMagic() error {
 				c.Node.NetworkMagic = 1
 			case "preview":
 				c.Node.NetworkMagic = 2
+			case "musashi":
+				c.Node.NetworkMagic = 164
 			default:
 				return errors.New("unknown network")
 			}
@@ -263,6 +265,8 @@ func (c *Config) populateNetworkMagic() error {
 				c.Node.NetworkMagic = 1
 			case "preview":
 				c.Node.NetworkMagic = 2
+			case "musashi":
+				c.Node.NetworkMagic = 164
 			default:
 				return errors.New("unknown network")
 			}
@@ -310,7 +314,7 @@ func (c *Config) populateByronGenesis() error {
 	if c.Node.ByronGenesis.SlotLength == 0 {
 		c.Node.ByronGenesis.SlotLength = 20000
 	}
-	// Our K is 2160, except preview, which we'll override below
+	// Our K is 2160, except preview/sancho/musashi, which we override below
 	kWasDefaulted := false
 	if c.Node.ByronGenesis.K == 0 {
 		c.Node.ByronGenesis.K = 2160
@@ -343,6 +347,13 @@ func (c *Config) populateByronGenesis() error {
 		}
 		if c.Node.ByronGenesis.StartTime == 0 {
 			c.Node.ByronGenesis.StartTime = 1686789000
+		}
+	case "musashi":
+		if kWasDefaulted {
+			c.Node.ByronGenesis.K = 432
+		}
+		if c.Node.ByronGenesis.StartTime == 0 {
+			c.Node.ByronGenesis.StartTime = 1780012800
 		}
 	case "mainnet":
 		if c.Node.ByronGenesis.StartTime == 0 {
@@ -379,10 +390,10 @@ func (c *Config) populateShelleyGenesis() error {
 	}
 
 	if c.Node.ShelleyGenesis.EpochLength == 0 {
-		// Our epoch length is 432000, except sanchonet/preview
+		// Our epoch length is 432000, except sanchonet/preview/musashi
 		c.Node.ShelleyGenesis.EpochLength = 432000
 		switch network {
-		case "sancho", "preview":
+		case "sancho", "preview", "musashi":
 			c.Node.ShelleyGenesis.EpochLength = 86400
 		}
 	} else {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -53,7 +53,9 @@ func TestPopulateNetworkMagic(t *testing.T) {
 		{"mainnet app", "mainnet", "", 764824073, false},
 		{"preprod app", "preprod", "", 1, false},
 		{"preview app", "preview", "", 2, false},
+		{"musashi app", "musashi", "", 164, false},
 		{"mainnet node", "", "mainnet", 764824073, false},
+		{"musashi node", "", "musashi", 164, false},
 		{"unknown app", "unknown", "", 0, true},
 		{"no network", "", "", 764824073, false}, // defaults to mainnet
 	}
@@ -98,6 +100,7 @@ func TestPopulateByronGenesis(t *testing.T) {
 		{"preprod app", "preprod", "", 1654041600, 2160},
 		{"preview app", "preview", "", 1666656000, 432},
 		{"sancho app", "sancho", "", 1686789000, 432},
+		{"musashi app", "musashi", "", 1780012800, 432},
 		{"mainnet node", "", "mainnet", 1506203091, 2160},
 	}
 
@@ -171,6 +174,7 @@ func TestPopulateShelleyGenesis(t *testing.T) {
 		{"preprod app", "preprod", "", 432000},
 		{"preview app", "preview", "", 86400},
 		{"sancho app", "sancho", "", 86400},
+		{"musashi app", "musashi", "", 86400},
 		{"mainnet node", "", "mainnet", 432000},
 	}
 
@@ -209,6 +213,7 @@ func TestPopulateShelleyTransEpoch(t *testing.T) {
 		{"mainnet app", "mainnet", "", 208},
 		{"preprod app", "preprod", "", 4},
 		{"preview app", "preview", "", 0}, // not set, defaults to 0
+		{"musashi app", "musashi", "", 0}, // all eras fork at epoch 0
 		{"mainnet node", "", "mainnet", 208},
 	}
 


### PR DESCRIPTION
Closes #476 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `musashi` named Cardano network with correct network magic and genesis defaults so nodes work out of the box. Also updates docs and examples to use `sancho` as the identifier.

- New Features
  - Added `musashi` network alias with NetworkMagic 164 for app and node config.
  - Byron: K=432, StartTime=1780012800. Shelley: EpochLength=86400. Transition epochs default to 0.
  - Updated `config.yaml.example`, tests, and comments: list `musashi`; use `sancho` (not `sanchonet`).

<sup>Written for commit b66ffbf1ad39d387f3831dd31855f2bf8833a183. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/nview/pull/477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional network shortcut values in configuration examples.
  * Enabled the new `musashi` network in network-based configuration defaults, including related genesis and epoch settings.

* **Bug Fixes**
  * Updated network-derived settings so `musashi` now uses the expected values for network identity, genesis timing, and epoch length.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->