### PR TITLE
fix: back off epoch update loop on zero epoch

### DIFF
--- a/main.go
+++ b/main.go
@@ -2750,23 +2750,7 @@ func main() {
 	}()
 
 	// Set Epoch
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-			}
-			setCurrentEpoch()
-			if currentEpoch != 0 {
-				select {
-				case <-ctx.Done():
-					return
-				case <-time.After(time.Second * 20):
-				}
-			}
-		}
-	}()
+	go runEpochUpdateLoop(ctx, time.Second*20, epochRetryDelay, setCurrentEpoch)
 
 	// Update Process metrics
 	go func() {

--- a/prometheus.go
+++ b/prometheus.go
@@ -22,6 +22,7 @@ import (
 	"slices"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/blinklabs-io/nview/internal/config"
 	dto "github.com/prometheus/client_model/go"
@@ -32,12 +33,46 @@ import (
 // Track current epoch
 var currentEpoch uint64 = 0
 
+// epochRetryDelay bounds how often the epoch update loop retries while the
+// current epoch is unavailable (zero), so a failed or not-yet-ready
+// Prometheus fetch cannot spin the loop continuously and consume a CPU core.
+const epochRetryDelay = time.Second * 5
+
 // Thread-safe node type detection
 var detectedNodeBinary atomic.Value // stores string
 
 func setCurrentEpoch() {
 	if promMetrics != nil {
 		currentEpoch = promMetrics.EpochNum
+	}
+}
+
+// runEpochUpdateLoop repeatedly calls update to refresh currentEpoch. It
+// waits refreshDelay between calls once a valid (nonzero) epoch has been
+// observed, but falls back to the shorter retryDelay while the epoch is
+// zero, so it backs off instead of busy-looping.
+func runEpochUpdateLoop(
+	ctx context.Context,
+	refreshDelay time.Duration,
+	retryDelay time.Duration,
+	update func(),
+) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		update()
+		delay := refreshDelay
+		if currentEpoch == 0 {
+			delay = retryDelay
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(delay):
+		}
 	}
 }
 

--- a/prometheus_test.go
+++ b/prometheus_test.go
@@ -802,7 +802,13 @@ func TestRunEpochUpdateLoopBacksOffOnZeroEpoch(t *testing.T) {
 	calls := make(chan struct{}, 1000)
 	update := func() {
 		// currentEpoch stays 0, simulating an unavailable epoch.
-		calls <- struct{}{}
+		// Non-blocking: if a busy-loop regression fills the buffer faster
+		// than the test drains it, update must still return so the loop
+		// can observe ctx cancellation instead of hanging on the send.
+		select {
+		case calls <- struct{}{}:
+		default:
+		}
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -856,7 +862,12 @@ func TestRunEpochUpdateLoopPreservesRefreshCadenceAfterValidEpoch(t *testing.T) 
 	calls := make(chan struct{}, 10)
 	update := func() {
 		currentEpoch = 100
-		calls <- struct{}{}
+		// Non-blocking for the same reason as the sibling test: a cadence
+		// regression must not be able to hang the deferred goroutine wait.
+		select {
+		case calls <- struct{}{}:
+		default:
+		}
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/prometheus_test.go
+++ b/prometheus_test.go
@@ -791,31 +791,53 @@ func TestGetEffectiveNodeName(t *testing.T) {
 
 // TestRunEpochUpdateLoopBacksOffOnZeroEpoch verifies that the epoch update
 // loop applies the bounded retry delay, rather than busy-looping, while the
-// observed epoch stays zero.
+// observed epoch stays zero. The timed measurement window starts only after
+// the first call is observed, so a scheduling stall before the loop's first
+// iteration cannot be mistaken for the retry backoff under test.
 func TestRunEpochUpdateLoopBacksOffOnZeroEpoch(t *testing.T) {
 	originalCurrentEpoch := currentEpoch
 	defer func() { currentEpoch = originalCurrentEpoch }()
 	currentEpoch = 0
 
-	var callCount int
+	calls := make(chan struct{}, 1000)
 	update := func() {
-		callCount++
 		// currentEpoch stays 0, simulating an unavailable epoch.
+		calls <- struct{}{}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 220*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runEpochUpdateLoop(ctx, time.Second*20, 50*time.Millisecond, update)
+	}()
+	defer func() { <-done }()
 	defer cancel()
 
-	runEpochUpdateLoop(ctx, time.Second*20, 50*time.Millisecond, update)
-
-	if callCount == 0 {
-		t.Fatal("expected update to be called at least once")
+	select {
+	case <-calls:
+	case <-time.After(2 * time.Second):
+		t.Fatal("update was never called")
 	}
+
+	callCount := 1
+	timer := time.NewTimer(220 * time.Millisecond)
+	defer timer.Stop()
+countLoop:
+	for {
+		select {
+		case <-calls:
+			callCount++
+		case <-timer.C:
+			break countLoop
+		}
+	}
+
 	// Without the retry backoff, a zero epoch would spin the loop
 	// continuously, producing thousands of calls in this window.
 	if callCount > 10 {
 		t.Fatalf(
-			"expected a bounded call count due to the retry delay, got %d calls in 220ms",
+			"expected a bounded call count due to the retry delay, got %d calls in ~220ms",
 			callCount,
 		)
 	}
@@ -823,27 +845,40 @@ func TestRunEpochUpdateLoopBacksOffOnZeroEpoch(t *testing.T) {
 
 // TestRunEpochUpdateLoopPreservesRefreshCadenceAfterValidEpoch verifies that
 // once a nonzero epoch is observed, the loop reverts to the normal (longer)
-// refresh cadence instead of continuing to retry quickly.
+// refresh cadence instead of continuing to retry quickly. It measures the
+// gap after the first observed call, rather than racing a fixed deadline
+// against that first call, so scheduling variance cannot fail the assertion.
 func TestRunEpochUpdateLoopPreservesRefreshCadenceAfterValidEpoch(t *testing.T) {
 	originalCurrentEpoch := currentEpoch
 	defer func() { currentEpoch = originalCurrentEpoch }()
 	currentEpoch = 0
 
-	var callCount int
+	calls := make(chan struct{}, 10)
 	update := func() {
-		callCount++
 		currentEpoch = 100
+		calls <- struct{}{}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runEpochUpdateLoop(ctx, 5*time.Second, 20*time.Millisecond, update)
+	}()
+	defer func() { <-done }()
 	defer cancel()
 
-	runEpochUpdateLoop(ctx, 5*time.Second, 20*time.Millisecond, update)
+	select {
+	case <-calls:
+	case <-time.After(2 * time.Second):
+		t.Fatal("update was never called")
+	}
 
-	if callCount != 1 {
-		t.Fatalf(
-			"expected exactly 1 call once a valid epoch is observed and the refresh cadence takes over, got %d",
-			callCount,
-		)
+	// Once a valid epoch is observed, the loop should be sleeping for the
+	// long refresh delay, so no further call should arrive quickly.
+	select {
+	case <-calls:
+		t.Fatal("expected no further call once the refresh cadence takes over")
+	case <-time.After(200 * time.Millisecond):
 	}
 }

--- a/prometheus_test.go
+++ b/prometheus_test.go
@@ -15,8 +15,10 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/nview/internal/config"
 	dto "github.com/prometheus/client_model/go"
@@ -784,5 +786,64 @@ func TestGetEffectiveNodeName(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+// TestRunEpochUpdateLoopBacksOffOnZeroEpoch verifies that the epoch update
+// loop applies the bounded retry delay, rather than busy-looping, while the
+// observed epoch stays zero.
+func TestRunEpochUpdateLoopBacksOffOnZeroEpoch(t *testing.T) {
+	originalCurrentEpoch := currentEpoch
+	defer func() { currentEpoch = originalCurrentEpoch }()
+	currentEpoch = 0
+
+	var callCount int
+	update := func() {
+		callCount++
+		// currentEpoch stays 0, simulating an unavailable epoch.
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 220*time.Millisecond)
+	defer cancel()
+
+	runEpochUpdateLoop(ctx, time.Second*20, 50*time.Millisecond, update)
+
+	if callCount == 0 {
+		t.Fatal("expected update to be called at least once")
+	}
+	// Without the retry backoff, a zero epoch would spin the loop
+	// continuously, producing thousands of calls in this window.
+	if callCount > 10 {
+		t.Fatalf(
+			"expected a bounded call count due to the retry delay, got %d calls in 220ms",
+			callCount,
+		)
+	}
+}
+
+// TestRunEpochUpdateLoopPreservesRefreshCadenceAfterValidEpoch verifies that
+// once a nonzero epoch is observed, the loop reverts to the normal (longer)
+// refresh cadence instead of continuing to retry quickly.
+func TestRunEpochUpdateLoopPreservesRefreshCadenceAfterValidEpoch(t *testing.T) {
+	originalCurrentEpoch := currentEpoch
+	defer func() { currentEpoch = originalCurrentEpoch }()
+	currentEpoch = 0
+
+	var callCount int
+	update := func() {
+		callCount++
+		currentEpoch = 100
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	runEpochUpdateLoop(ctx, 5*time.Second, 20*time.Millisecond, update)
+
+	if callCount != 1 {
+		t.Fatalf(
+			"expected exactly 1 call once a valid epoch is observed and the refresh cadence takes over, got %d",
+			callCount,
+		)
 	}
 }


### PR DESCRIPTION
Fixes #499.

The epoch update goroutine only slept between attempts when the fetched
epoch was nonzero. A zero value (startup, or Prometheus metrics not yet
populated) or a failed initialization left `currentEpoch` at 0, so the
loop looped back immediately with no delay and pinned a CPU core.

## Changes

- **`prometheus.go`**: added `epochRetryDelay` (5s) and extracted the
  loop body into `runEpochUpdateLoop(ctx, refreshDelay, retryDelay,
  update)`. It always waits between attempts: `retryDelay` while
  `currentEpoch == 0`, `refreshDelay` (20s, unchanged) once a valid
  epoch is observed.
- **`main.go`**: replaced the inline goroutine with a call to
  `runEpochUpdateLoop(ctx, time.Second*20, epochRetryDelay,
  setCurrentEpoch)`.
- **`prometheus_test.go`**: added `TestRunEpochUpdateLoopBacksOffOnZeroEpoch`,
  which runs the loop for 220ms with the epoch held at zero and asserts
  the update function is called at most 10 times (unbounded prior to
  this fix), and `TestRunEpochUpdateLoopPreservesRefreshCadenceAfterValidEpoch`,
  which asserts the loop reverts to the normal 20s cadence once a valid
  epoch is observed.

## Testing

- `go build ./...`
- `go vet ./...`
- `gofmt -l .`
- `golangci-lint run ./...`
- `go test -v -race -count=1 ./...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #499. The epoch update goroutine busy-looped and pinned a CPU core when the epoch was zero (startup or Prometheus metrics not yet populated), because it only slept between updates after receiving a nonzero epoch.

Extracts the loop into `runEpochUpdateLoop`, which always waits: 5s while the epoch is zero, the normal 20s once a valid epoch is observed. Adds two tests covering the backoff on zero epoch and the preserved refresh cadence after a valid epoch, synchronized on the first observed call so scheduling variance can't race the assertions.

<sup>Written for commit e26174d7449e8ff52e1a398cfc2f9291f468bcd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/nview/pull/503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved epoch updates when no valid epoch is available by retrying after a short delay instead of repeatedly checking without pause.
  - Restored the normal refresh cadence once a valid epoch is observed.
  - Epoch update processing now stops promptly when the application context is canceled.

- **Tests**
  - Added coverage for retry timing and the return to the standard refresh cadence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->