### PR TITLE
fix: avoid panic when node cmdline has trailing --config

### DIFF
--- a/node.go
+++ b/node.go
@@ -83,8 +83,9 @@ func getP2P(ctx context.Context, processMetrics *process.Process) bool {
 // "--config <path>" argument and returns the EnableP2P setting from that
 // config file. It validates that "--config" has a following value before
 // indexing the argument list, returning errMissingConfigValue instead of
-// panicking on a trailing "--config". current is returned unchanged when a
-// "--config" occurrence is missing its value or names an unreadable file.
+// panicking on a trailing "--config". The last "--config" occurrence is
+// authoritative: current is returned when it is missing its value or names
+// an unreadable file, even if an earlier occurrence parsed successfully.
 func p2pFromNodeConfigCmdline(cmd string, current bool) (bool, error) {
 	cmdArray := strings.Split(cmd, " ")
 	result := current
@@ -94,12 +95,14 @@ func p2pFromNodeConfigCmdline(cmd string, current bool) (bool, error) {
 			continue
 		}
 		if p+1 >= len(cmdArray) {
+			result = current
 			err = errMissingConfigValue
 			continue
 		}
 		nodeConfigFile := cmdArray[p+1]
 		buf, readErr := os.ReadFile(nodeConfigFile)
 		if readErr != nil {
+			result = current
 			err = readErr
 			continue
 		}

--- a/node.go
+++ b/node.go
@@ -17,12 +17,18 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"strings"
 
 	"github.com/blinklabs-io/nview/internal/config"
 	"github.com/shirou/gopsutil/v3/process"
 )
+
+// errMissingConfigValue is a stable, comparable error returned when a
+// "--config" argument in a monitored process's command line has no
+// following value.
+var errMissingConfigValue = errors.New("--config flag has no value")
 
 var (
 	p2p  bool   = true
@@ -59,27 +65,55 @@ func getP2P(ctx context.Context, processMetrics *process.Process) bool {
 		if err == nil {
 			if !strings.Contains(cmd, "p2p") &&
 				strings.Contains(cmd, "--config") {
-				cmdArray := strings.Split(cmd, " ")
-				for p, arg := range cmdArray {
-					if arg == "--config" {
-						nodeConfigFile := cmdArray[p+1]
-						buf, err := os.ReadFile(nodeConfigFile)
-						if err == nil {
-							type nodeConfig struct {
-								EnableP2P bool `json:"EnableP2P"`
-							}
-							var nc nodeConfig
-							err = json.Unmarshal(buf, &nc)
-							if err != nil {
-								p2p = false
-							} else {
-								p2p = nc.EnableP2P
-							}
-						}
-					}
+				newP2P, err := p2pFromNodeConfigCmdline(cmd, p2p)
+				if err != nil && logger != nil {
+					logger.Warn(
+						"could not determine P2P setting from node config",
+						"error", err,
+					)
 				}
+				p2p = newP2P
 			}
 		}
 	}
 	return p2p
+}
+
+// p2pFromNodeConfigCmdline inspects a cardano-node command line for a
+// "--config <path>" argument and returns the EnableP2P setting from that
+// config file. It validates that "--config" has a following value before
+// indexing the argument list, returning errMissingConfigValue instead of
+// panicking on a trailing "--config". current is returned unchanged when a
+// "--config" occurrence is missing its value or names an unreadable file.
+func p2pFromNodeConfigCmdline(cmd string, current bool) (bool, error) {
+	cmdArray := strings.Split(cmd, " ")
+	result := current
+	var err error
+	for p, arg := range cmdArray {
+		if arg != "--config" {
+			continue
+		}
+		if p+1 >= len(cmdArray) {
+			err = errMissingConfigValue
+			continue
+		}
+		nodeConfigFile := cmdArray[p+1]
+		buf, readErr := os.ReadFile(nodeConfigFile)
+		if readErr != nil {
+			err = readErr
+			continue
+		}
+		type nodeConfig struct {
+			EnableP2P bool `json:"EnableP2P"`
+		}
+		var nc nodeConfig
+		if unmarshalErr := json.Unmarshal(buf, &nc); unmarshalErr != nil {
+			result = false
+			err = unmarshalErr
+		} else {
+			result = nc.EnableP2P
+			err = nil
+		}
+	}
+	return result, err
 }

--- a/node_test.go
+++ b/node_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeNodeConfigFixture(t *testing.T, enableP2P bool) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.json")
+	content := `{"EnableP2P": false}`
+	if enableP2P {
+		content = `{"EnableP2P": true}`
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write fixture: %v", err)
+	}
+	return path
+}
+
+// --config is the first argument on the command line; its value should
+// still be found and used.
+func TestP2PFromNodeConfigCmdlineLeadingConfig(t *testing.T) {
+	path := writeNodeConfigFixture(t, true)
+	cmd := "--config " + path + " --extra flag"
+	got, err := p2pFromNodeConfigCmdline(cmd, false)
+	if err != nil {
+		t.Fatalf("p2pFromNodeConfigCmdline() error = %v, want nil", err)
+	}
+	if got != true {
+		t.Fatalf("p2pFromNodeConfigCmdline() = %v, want true", got)
+	}
+}
+
+// --config sits between other arguments, the common real-world case.
+func TestP2PFromNodeConfigCmdlineMiddleConfig(t *testing.T) {
+	path := writeNodeConfigFixture(t, true)
+	cmd := "cardano-node run --config " + path + " --other flag"
+	got, err := p2pFromNodeConfigCmdline(cmd, false)
+	if err != nil {
+		t.Fatalf("p2pFromNodeConfigCmdline() error = %v, want nil", err)
+	}
+	if got != true {
+		t.Fatalf("p2pFromNodeConfigCmdline() = %v, want true", got)
+	}
+}
+
+// --config is the last argument with no value after it. This is the exact
+// input that used to panic (issue #500); it must now return
+// errMissingConfigValue and leave the current P2P value untouched instead.
+func TestP2PFromNodeConfigCmdlineTrailingConfigDoesNotPanic(t *testing.T) {
+	cmd := "cardano-node run --other flag --config"
+	got, err := p2pFromNodeConfigCmdline(cmd, true)
+	if !errors.Is(err, errMissingConfigValue) {
+		t.Fatalf("p2pFromNodeConfigCmdline() error = %v, want errMissingConfigValue", err)
+	}
+	if got != true {
+		t.Fatalf("p2pFromNodeConfigCmdline() = %v, want unchanged current value true", got)
+	}
+}
+
+// --config appears twice, pointing at two different config files. The
+// second (last) occurrence should win.
+func TestP2PFromNodeConfigCmdlineRepeatedConfigUsesLast(t *testing.T) {
+	firstPath := writeNodeConfigFixture(t, false)
+	lastPath := writeNodeConfigFixture(t, true)
+	cmd := "--config " + firstPath + " --config " + lastPath
+	got, err := p2pFromNodeConfigCmdline(cmd, false)
+	if err != nil {
+		t.Fatalf("p2pFromNodeConfigCmdline() error = %v, want nil", err)
+	}
+	if got != true {
+		t.Fatalf("p2pFromNodeConfigCmdline() = %v, want true from last --config", got)
+	}
+}
+
+// --config is followed by an empty string instead of a real path (not
+// missing, just blank). Reading that "file" fails, so the current P2P
+// value should be left unchanged rather than being reset.
+func TestP2PFromNodeConfigCmdlineEmptyValueLeavesCurrentUnchanged(t *testing.T) {
+	cmd := "cardano-node run --config  --other flag"
+	got, err := p2pFromNodeConfigCmdline(cmd, true)
+	if err == nil {
+		t.Fatal("p2pFromNodeConfigCmdline() error = nil, want a read error for the empty path")
+	}
+	if got != true {
+		t.Fatalf("p2pFromNodeConfigCmdline() = %v, want unchanged current value true", got)
+	}
+}

--- a/node_test.go
+++ b/node_test.go
@@ -90,6 +90,37 @@ func TestP2PFromNodeConfigCmdlineRepeatedConfigUsesLast(t *testing.T) {
 	}
 }
 
+// --config appears twice: the first occurrence is valid, but the second
+// (last) is missing its value. The earlier valid parse must not leak
+// through — the last occurrence is authoritative, so the result should
+// fall back to the incoming current value, not the first --config's file.
+func TestP2PFromNodeConfigCmdlineRepeatedConfigLastMissingValue(t *testing.T) {
+	firstPath := writeNodeConfigFixture(t, true)
+	cmd := "--config " + firstPath + " --config"
+	got, err := p2pFromNodeConfigCmdline(cmd, false)
+	if !errors.Is(err, errMissingConfigValue) {
+		t.Fatalf("p2pFromNodeConfigCmdline() error = %v, want errMissingConfigValue", err)
+	}
+	if got != false {
+		t.Fatalf("p2pFromNodeConfigCmdline() = %v, want incoming current value false", got)
+	}
+}
+
+// --config appears twice: the first occurrence is valid, but the second
+// (last) names a file that does not exist. As above, the last occurrence's
+// failure must win over the earlier valid parse.
+func TestP2PFromNodeConfigCmdlineRepeatedConfigLastUnreadable(t *testing.T) {
+	firstPath := writeNodeConfigFixture(t, true)
+	cmd := "--config " + firstPath + " --config /nonexistent/path/config.json"
+	got, err := p2pFromNodeConfigCmdline(cmd, false)
+	if err == nil {
+		t.Fatal("p2pFromNodeConfigCmdline() error = nil, want a read error for the missing file")
+	}
+	if got != false {
+		t.Fatalf("p2pFromNodeConfigCmdline() = %v, want incoming current value false", got)
+	}
+}
+
 // --config is followed by an empty string instead of a real path (not
 // missing, just blank). Reading that "file" fails, so the current P2P
 // value should be left unchanged rather than being reset.


### PR DESCRIPTION
## Summary

`getP2P()` infers the monitored cardano-node's P2P setting by scanning its
command line for a `--config <path>` argument. It read the element after
`--config` by indexing `cmdArray[p+1]` without checking that a following
element exists, so a command line ending in `--config` with no value
panicked with an out-of-range index.

## Changes

- **`node.go`**
  - Extracted the cmdline scan out of `getP2P()` into a standalone,
    testable function `p2pFromNodeConfigCmdline(cmd string, current bool) (bool, error)`.
  - Added a bounds check before indexing `cmdArray[p+1]`.
  - Added a stable, comparable sentinel error `errMissingConfigValue`,
    returned instead of panicking when `--config` has no following value.
  - `getP2P()` now logs a warning (`logger.Warn`, guarded `logger != nil` to
    match existing call sites) when the scan returns an error, instead of
    dropping it silently. The current P2P value is preserved whenever
    `--config` is missing its value or names an unreadable file.

- **`node_test.go`** (new)
  - `TestP2PFromNodeConfigCmdlineLeadingConfig` — `--config` is the first
    argument.
  - `TestP2PFromNodeConfigCmdlineMiddleConfig` — `--config` sits between
    other arguments (the common case).
  - `TestP2PFromNodeConfigCmdlineTrailingConfigDoesNotPanic` — `--config` is
    the last argument with no value after it; this is the exact input that
    used to panic. Asserts `errors.Is(err, errMissingConfigValue)` and that
    the current value is left unchanged.
  - `TestP2PFromNodeConfigCmdlineRepeatedConfigUsesLast` — `--config`
    appears twice; the last occurrence wins.
  - `TestP2PFromNodeConfigCmdlineEmptyValueLeavesCurrentUnchanged` —
    `--config` is followed by an empty string; the read fails and the
    current value is preserved.

Fixes #500

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a panic in `getP2P()` when a monitored cardano-node command line ends with `--config` without a following value. The scan now returns a stable `errMissingConfigValue` instead of panicking, preserves the current P2P value when the config is missing or unreadable, and logs a warning. When `--config` appears multiple times, the last occurrence is now authoritative, so an earlier valid parse doesn't leak through. Fixes #500.

**Refactors**
- Pulled the command-line scan into a testable `p2pFromNodeConfigCmdline` function.
- Added tests for leading, middle, trailing, repeated (last occurrence wins), and empty-value `--config` arguments.

<sup>Written for commit e97e4779c0fd4452745ab93e5a38da109b656039. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/nview/pull/504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of node configuration arguments, including missing, empty, unreadable, and repeated configuration values.
  - Preserved the existing peer-to-peer setting when configuration values cannot be read.
  - Added clearer error reporting for invalid configuration arguments.

- **Tests**
  - Added coverage for configuration arguments in different positions, repeated values, missing values, and unreadable files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->