### PR TITLE
fix: bound metrics response reads and always close the body

### DIFF
--- a/env.go
+++ b/env.go
@@ -26,6 +26,17 @@ import (
 	"github.com/blinklabs-io/nview/internal/config"
 )
 
+// maxMetricsResponseBytes bounds how much of the node's metrics response is
+// read into memory. It is a var rather than a const so tests can lower it
+// without generating multi-megabyte payloads.
+var maxMetricsResponseBytes int64 = 10 * 1024 * 1024 // 10 MiB
+
+// errMetricsResponseTooLarge is returned when the node's metrics response
+// exceeds maxMetricsResponseBytes.
+var errMetricsResponseTooLarge = errors.New(
+	"metrics response exceeds maximum allowed size",
+)
+
 // Fetches the node metrics and return a byte array
 func getNodeMetrics(ctx context.Context) ([]byte, int, error) {
 	// Load our config and get host/port
@@ -46,7 +57,7 @@ func getNodeMetrics(ctx context.Context) ([]byte, int, error) {
 	if err != nil {
 		return respBodyBytes, http.StatusInternalServerError, err
 	}
-	// Set a 3 second timeout
+	// Set a deadline covering the whole request, including reading the body
 	ctx, cancel := context.WithTimeout(
 		ctx,
 		time.Second*time.Duration(cfg.Prometheus.Timeout),
@@ -63,12 +74,20 @@ func getNodeMetrics(ctx context.Context) ([]byte, int, error) {
 			"empty response",
 		)
 	}
-	// Read the entire response body and close it to prevent a memory leak
-	respBodyBytes, err = io.ReadAll(resp.Body)
+	// Close the body as soon as the request succeeds, regardless of what
+	// happens while reading it, so a read error or an oversized response
+	// cannot leave the connection open.
+	defer resp.Body.Close()
+	// Read one byte past the limit so an oversized response can be
+	// distinguished from one that lands exactly on the limit.
+	limitedBody := io.LimitReader(resp.Body, maxMetricsResponseBytes+1)
+	respBodyBytes, err = io.ReadAll(limitedBody)
 	if err != nil {
 		return respBodyBytes, http.StatusInternalServerError, err
 	}
-	defer resp.Body.Close()
+	if int64(len(respBodyBytes)) > maxMetricsResponseBytes {
+		return respBodyBytes, http.StatusInternalServerError, errMetricsResponseTooLarge
+	}
 	return respBodyBytes, resp.StatusCode, nil
 }
 

--- a/env.go
+++ b/env.go
@@ -37,6 +37,11 @@ var errMetricsResponseTooLarge = errors.New(
 	"metrics response exceeds maximum allowed size",
 )
 
+// httpClient is the client used to fetch node metrics. It is a var, scoped
+// to this file, so tests can substitute a client with an instrumented
+// transport without mutating the process-wide http.DefaultClient.
+var httpClient = http.DefaultClient
+
 // Fetches the node metrics and return a byte array
 func getNodeMetrics(ctx context.Context) ([]byte, int, error) {
 	// Load our config and get host/port
@@ -65,7 +70,7 @@ func getNodeMetrics(ctx context.Context) ([]byte, int, error) {
 	defer cancel()
 	req = req.WithContext(ctx)
 	// Get metrics from the node
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return respBodyBytes, http.StatusInternalServerError, err
 	}

--- a/env_test.go
+++ b/env_test.go
@@ -1,0 +1,225 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/nview/internal/config"
+)
+
+// bodyCloseTracker wraps a response body and records whether Close was
+// called on it.
+type bodyCloseTracker struct {
+	io.ReadCloser
+	closed *atomic.Bool
+}
+
+func (b *bodyCloseTracker) Close() error {
+	b.closed.Store(true)
+	return b.ReadCloser.Close()
+}
+
+// trackingRoundTripper wraps http.DefaultTransport so tests can observe
+// whether getNodeMetrics closed the response body it received.
+type trackingRoundTripper struct {
+	closed *atomic.Bool
+}
+
+func (t *trackingRoundTripper) RoundTrip(
+	req *http.Request,
+) (*http.Response, error) {
+	//nolint:usestdlibvars
+	resp, err := http.DefaultTransport.RoundTrip(req)
+	if resp != nil {
+		resp.Body = &bodyCloseTracker{ReadCloser: resp.Body, closed: t.closed}
+	}
+	return resp, err
+}
+
+// pointDefaultClientAtTestServer configures cfg.Prometheus to reach server
+// and installs a tracking transport on http.DefaultClient, restoring both
+// when the test ends. It returns the flag the tracking transport sets when
+// the response body is closed.
+func pointDefaultClientAtTestServer(
+	t *testing.T,
+	server *httptest.Server,
+	timeoutSeconds uint32,
+) *atomic.Bool {
+	t.Helper()
+
+	host, portStr, err := net.SplitHostPort(
+		strings.TrimPrefix(server.URL, "http://"),
+	)
+	if err != nil {
+		t.Fatalf("failed to parse test server address: %v", err)
+	}
+	port, err := strconv.ParseUint(portStr, 10, 32)
+	if err != nil {
+		t.Fatalf("failed to parse test server port: %v", err)
+	}
+
+	cfg := config.GetConfig()
+	origHost := cfg.Prometheus.Host
+	origPort := cfg.Prometheus.Port
+	origTimeout := cfg.Prometheus.Timeout
+	cfg.Prometheus.Host = host
+	cfg.Prometheus.Port = uint32(port)
+	cfg.Prometheus.Timeout = timeoutSeconds
+
+	origTransport := http.DefaultClient.Transport
+	closed := &atomic.Bool{}
+	http.DefaultClient.Transport = &trackingRoundTripper{closed: closed}
+
+	t.Cleanup(func() {
+		cfg.Prometheus.Host = origHost
+		cfg.Prometheus.Port = origPort
+		cfg.Prometheus.Timeout = origTimeout
+		http.DefaultClient.Transport = origTransport
+	})
+
+	return closed
+}
+
+// TestGetNodeMetricsSuccessClosesBody is a sanity check that the happy path
+// still returns the response body and closes it.
+func TestGetNodeMetricsSuccessClosesBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("metric_a 1\n"))
+		},
+	))
+	defer server.Close()
+
+	closed := pointDefaultClientAtTestServer(t, server, 3)
+
+	body, status, err := getNodeMetrics(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", status)
+	}
+	if string(body) != "metric_a 1\n" {
+		t.Fatalf("unexpected body: %q", body)
+	}
+	if !closed.Load() {
+		t.Fatal("expected response body to be closed")
+	}
+}
+
+// TestGetNodeMetricsOversizedResponseClosesBody verifies that a response
+// larger than maxMetricsResponseBytes is rejected with a distinct error and
+// that the body is still closed.
+func TestGetNodeMetricsOversizedResponseClosesBody(t *testing.T) {
+	originalMax := maxMetricsResponseBytes
+	defer func() { maxMetricsResponseBytes = originalMax }()
+	maxMetricsResponseBytes = 16
+
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(bytes.Repeat([]byte("x"), 64))
+		},
+	))
+	defer server.Close()
+
+	closed := pointDefaultClientAtTestServer(t, server, 3)
+
+	_, _, err := getNodeMetrics(context.Background())
+	if !errors.Is(err, errMetricsResponseTooLarge) {
+		t.Fatalf("expected errMetricsResponseTooLarge, got %v", err)
+	}
+	if !closed.Load() {
+		t.Fatal("expected response body to be closed")
+	}
+}
+
+// TestGetNodeMetricsStalledResponseClosesBody verifies that a response whose
+// body stalls after headers are sent is aborted by the request deadline
+// (rather than hanging or reading unbounded data) and that the body is
+// still closed.
+func TestGetNodeMetricsStalledResponseClosesBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			// Stall past the client's request deadline instead of ever
+			// completing the response.
+			select {
+			case <-r.Context().Done():
+			case <-time.After(5 * time.Second):
+			}
+		},
+	))
+	defer server.Close()
+
+	closed := pointDefaultClientAtTestServer(t, server, 1)
+
+	start := time.Now()
+	_, _, err := getNodeMetrics(context.Background())
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error from a stalled response")
+	}
+	if elapsed > 4*time.Second {
+		t.Fatalf(
+			"expected the request deadline to abort the stalled read quickly, took %s",
+			elapsed,
+		)
+	}
+	if !closed.Load() {
+		t.Fatal("expected response body to be closed")
+	}
+}
+
+// TestGetNodeMetricsReadErrorClosesBody verifies that a response truncated
+// mid-body (fewer bytes than the declared Content-Length) surfaces a read
+// error and still closes the body.
+func TestGetNodeMetricsReadErrorClosesBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Length", "1000")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("short"))
+		},
+	))
+	defer server.Close()
+
+	closed := pointDefaultClientAtTestServer(t, server, 3)
+
+	_, _, err := getNodeMetrics(context.Background())
+	if err == nil {
+		t.Fatal("expected a read error from a truncated response")
+	}
+	if !closed.Load() {
+		t.Fatal("expected response body to be closed")
+	}
+}

--- a/env_test.go
+++ b/env_test.go
@@ -60,11 +60,13 @@ func (t *trackingRoundTripper) RoundTrip(
 	return resp, err
 }
 
-// pointDefaultClientAtTestServer configures cfg.Prometheus to reach server
-// and installs a tracking transport on http.DefaultClient, restoring both
-// when the test ends. It returns the flag the tracking transport sets when
-// the response body is closed.
-func pointDefaultClientAtTestServer(
+// pointMetricsClientAtTestServer configures cfg.Prometheus to reach server
+// and substitutes the package-level httpClient with one wrapping an
+// instrumented transport, restoring both when the test ends. It never
+// touches the process-wide http.DefaultClient, so it stays safe even if a
+// future test in this package runs in parallel. It returns the flag the
+// tracking transport sets when the response body is closed.
+func pointMetricsClientAtTestServer(
 	t *testing.T,
 	server *httptest.Server,
 	timeoutSeconds uint32,
@@ -90,15 +92,15 @@ func pointDefaultClientAtTestServer(
 	cfg.Prometheus.Port = uint32(port)
 	cfg.Prometheus.Timeout = timeoutSeconds
 
-	origTransport := http.DefaultClient.Transport
+	origClient := httpClient
 	closed := &atomic.Bool{}
-	http.DefaultClient.Transport = &trackingRoundTripper{closed: closed}
+	httpClient = &http.Client{Transport: &trackingRoundTripper{closed: closed}}
 
 	t.Cleanup(func() {
 		cfg.Prometheus.Host = origHost
 		cfg.Prometheus.Port = origPort
 		cfg.Prometheus.Timeout = origTimeout
-		http.DefaultClient.Transport = origTransport
+		httpClient = origClient
 	})
 
 	return closed
@@ -115,7 +117,7 @@ func TestGetNodeMetricsSuccessClosesBody(t *testing.T) {
 	))
 	defer server.Close()
 
-	closed := pointDefaultClientAtTestServer(t, server, 3)
+	closed := pointMetricsClientAtTestServer(t, server, 3)
 
 	body, status, err := getNodeMetrics(context.Background())
 	if err != nil {
@@ -148,7 +150,7 @@ func TestGetNodeMetricsOversizedResponseClosesBody(t *testing.T) {
 	))
 	defer server.Close()
 
-	closed := pointDefaultClientAtTestServer(t, server, 3)
+	closed := pointMetricsClientAtTestServer(t, server, 3)
 
 	_, _, err := getNodeMetrics(context.Background())
 	if !errors.Is(err, errMetricsResponseTooLarge) {
@@ -162,7 +164,9 @@ func TestGetNodeMetricsOversizedResponseClosesBody(t *testing.T) {
 // TestGetNodeMetricsStalledResponseClosesBody verifies that a response whose
 // body stalls after headers are sent is aborted by the request deadline
 // (rather than hanging or reading unbounded data) and that the body is
-// still closed.
+// still closed. It waits on a generous safety timeout rather than asserting
+// a tight wall-clock bound, so scheduling variance on a loaded CI runner
+// cannot make it flaky.
 func TestGetNodeMetricsStalledResponseClosesBody(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
@@ -170,7 +174,7 @@ func TestGetNodeMetricsStalledResponseClosesBody(t *testing.T) {
 			if f, ok := w.(http.Flusher); ok {
 				f.Flush()
 			}
-			// Stall past the client's request deadline instead of ever
+			// Stall until the client disconnects, instead of ever
 			// completing the response.
 			select {
 			case <-r.Context().Done():
@@ -180,19 +184,22 @@ func TestGetNodeMetricsStalledResponseClosesBody(t *testing.T) {
 	))
 	defer server.Close()
 
-	closed := pointDefaultClientAtTestServer(t, server, 1)
+	closed := pointMetricsClientAtTestServer(t, server, 1)
 
-	start := time.Now()
-	_, _, err := getNodeMetrics(context.Background())
-	elapsed := time.Since(start)
+	errCh := make(chan error, 1)
+	go func() {
+		_, _, err := getNodeMetrics(context.Background())
+		errCh <- err
+	}()
 
-	if err == nil {
-		t.Fatal("expected an error from a stalled response")
-	}
-	if elapsed > 4*time.Second {
-		t.Fatalf(
-			"expected the request deadline to abort the stalled read quickly, took %s",
-			elapsed,
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("expected an error from a stalled response")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal(
+			"getNodeMetrics did not return after the request deadline elapsed",
 		)
 	}
 	if !closed.Load() {
@@ -213,7 +220,7 @@ func TestGetNodeMetricsReadErrorClosesBody(t *testing.T) {
 	))
 	defer server.Close()
 
-	closed := pointDefaultClientAtTestServer(t, server, 3)
+	closed := pointMetricsClientAtTestServer(t, server, 3)
 
 	_, _, err := getNodeMetrics(context.Background())
 	if err == nil {


### PR DESCRIPTION
Fixes #501.

`getNodeMetrics` only closed the response body after a successful
`io.ReadAll`, so any read error left the connection open. `io.ReadAll`
also had no size limit, so a large or stalled response could be read
entirely into memory.

## Changes

- **`env.go`**: added `maxMetricsResponseBytes` (10 MiB, a `var` so
  tests can lower it) and `errMetricsResponseTooLarge`. Moved
  `defer resp.Body.Close()` to fire immediately once a response is
  received, before any read is attempted, so it always runs regardless
  of what the read does. Wrapped the body in
  `io.LimitReader(resp.Body, maxMetricsResponseBytes+1)` before reading,
  reading one byte past the cap to distinguish an oversized response
  from one that lands exactly on the limit, and return
  `errMetricsResponseTooLarge` when it is exceeded. The existing
  request context timeout already bounds the whole request including
  the body read, so no separate deadline was needed.
- **`env_test.go`** (new): a tracking `http.RoundTripper` wraps
  `http.DefaultClient` so tests can observe whether the body was
  actually closed. Added:
  - `TestGetNodeMetricsSuccessClosesBody` — happy-path sanity check.
  - `TestGetNodeMetricsOversizedResponseClosesBody` — lowers the size
    cap and confirms `errMetricsResponseTooLarge` and body closure.
  - `TestGetNodeMetricsStalledResponseClosesBody` — server sends
    headers then hangs; confirms the request deadline aborts it
    quickly and the body still closes.
  - `TestGetNodeMetricsReadErrorClosesBody` — server declares a
    `Content-Length` larger than what it writes, forcing a real
    mid-body read error; confirms body closure.

## Testing

- `go build ./...`
- `go vet ./...`
- `gofmt -l .`
- `golangci-lint run ./...`
- `go test -v -race -count=1 ./...`
- Ran the read-error test against the pre-fix `getNodeMetrics` logic
  directly and confirmed it left the body unclosed, verifying the test
  catches the real regression.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #501 so `getNodeMetrics` no longer leaks connections on read errors and bounds how much of the metrics response it reads into memory. The response body now always closes as soon as the request succeeds, and reads are capped at 10 MiB with a distinct error for oversized responses. The existing request timeout still bounds the whole request.

- Adds a package-level `httpClient` var so tests substitute it instead of the process-wide `http.DefaultClient`.
- Adds tests verifying body closure on success, oversized, stalled, and mid-body read-error responses; the stalled-response test waits on a safety timeout instead of asserting wall-clock time.

<sup>Written for commit 9b37bde45876b2b2daf789abaf92d3a501aebd70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/nview/pull/505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Limits the amount of node metrics data read into memory, returning an error for responses exceeding the configured limit.
  - Ensures metrics response connections are closed consistently, including successful, oversized, stalled, and truncated responses.

- **Tests**
  - Added coverage for response-size limits, request deadlines, read errors, and response cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->