### PR TITLE
fix: publish race-free metric snapshots, track health per subsystem

### DIFF
--- a/health.go
+++ b/health.go
@@ -1,0 +1,61 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "sync/atomic"
+
+// healthSubsystem identifies an independent background subsystem whose
+// consecutive failures are tracked separately, so a success in one
+// subsystem (for example peer probing) can never mask an ongoing failure in
+// another (for example the Prometheus scrape loop), and so a single failed
+// attempt in one subsystem is never counted against another.
+type healthSubsystem int
+
+const (
+	healthSubsystemPrometheus healthSubsystem = iota
+	healthSubsystemProcess
+	healthSubsystemPeers
+	healthSubsystemCount
+)
+
+var subsystemFailures [healthSubsystemCount]atomic.Uint32
+
+// recordSubsystemFailure records a failed attempt for the given subsystem.
+// Each attempt must record exactly one outcome (recordSubsystemFailure or
+// recordSubsystemSuccess) so a single failed attempt is never
+// double-counted.
+func recordSubsystemFailure(s healthSubsystem) {
+	subsystemFailures[s].Add(1)
+}
+
+// recordSubsystemSuccess clears the given subsystem's consecutive-failure
+// count. Call it only for that subsystem's own successful attempts, never
+// on behalf of an unrelated subsystem.
+func recordSubsystemSuccess(s healthSubsystem) {
+	subsystemFailures[s].Store(0)
+}
+
+// failCount reports the worst consecutive-failure streak across all
+// tracked subsystems. It drives the overall dashboard health indicator and
+// the connect-retry panic threshold.
+func failCount() uint32 {
+	var worst uint32
+	for i := range subsystemFailures {
+		if v := subsystemFailures[i].Load(); v > worst {
+			worst = v
+		}
+	}
+	return worst
+}

--- a/health_test.go
+++ b/health_test.go
@@ -16,12 +16,20 @@ package main
 
 import (
 	"context"
+	"errors"
+	"net/http"
 	"sync"
 	"sync/atomic"
 	"testing"
 
 	"github.com/blinklabs-io/nview/internal/config"
 )
+
+type failingMetricsTransport struct{}
+
+func (failingMetricsTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, errors.New("metrics endpoint unavailable")
+}
 
 // resetSubsystemFailuresForTest zeroes every subsystem's consecutive-failure
 // count and returns the prior values so a test can restore them.
@@ -140,10 +148,10 @@ func TestGetPromMetricsAppliesResultExactlyOnce(t *testing.T) {
 		cfg.Prometheus.Port = originalPort
 		cfg.Prometheus.Timeout = originalTimeout
 	}()
-	// Port 0 is never a listening Prometheus endpoint, so the request fails
-	// immediately instead of depending on network timing.
-	cfg.Prometheus.Host = "127.0.0.1"
-	cfg.Prometheus.Port = 0
+	// Use a deterministic transport failure instead of opening a loopback socket.
+	originalClient := httpClient
+	httpClient = &http.Client{Transport: failingMetricsTransport{}}
+	defer func() { httpClient = originalClient }()
 	cfg.Prometheus.Timeout = 1
 
 	ctx := context.Background()

--- a/health_test.go
+++ b/health_test.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/blinklabs-io/nview/internal/config"
@@ -159,10 +160,19 @@ func TestGetPromMetricsAppliesResultExactlyOnce(t *testing.T) {
 
 // TestConcurrentPromMetricsPublicationAndRendering exercises the scrape
 // goroutine's snapshot publication concurrently with renderer goroutines
-// reading it, under the race detector. Before promMetrics became an
-// atomic.Pointer[PromMetrics], this same access pattern (an unsynchronized
-// package-level *PromMetrics written by one goroutine and read by others)
-// raced. Run with `go test -race` to verify no race is reported.
+// reading it. Run with `go test -race` to additionally verify no data race
+// is reported; before promMetrics became an atomic.Pointer[PromMetrics],
+// this same access pattern (an unsynchronized package-level *PromMetrics
+// written by one goroutine and read by others) raced.
+//
+// The race detector alone would make this test a silent no-op under a plain
+// `go test ./...` (the CI workflow does not pass -race), so a consistency
+// reader also asserts, on every observed snapshot, that BlockNum, SlotNum,
+// and EpochNum still satisfy the writer's invariant. That fails
+// deterministically, with or without -race, if publication ever stopped
+// being a whole-struct replacement (for example a future change that
+// mutated fields on the shared struct in place, which could let a reader
+// observe some fields from one write and some from the next).
 func TestConcurrentPromMetricsPublicationAndRendering(t *testing.T) {
 	originalPromMetrics := promMetrics.Load()
 	defer promMetrics.Store(originalPromMetrics)
@@ -177,9 +187,12 @@ func TestConcurrentPromMetricsPublicationAndRendering(t *testing.T) {
 
 	const iterations = 200
 	var wg sync.WaitGroup
+	var inconsistent atomic.Bool
 
 	// Writer: mimics the scrape goroutine publishing a fresh, complete
-	// snapshot on every attempt.
+	// snapshot on every attempt. BlockNum and SlotNum always match, and
+	// EpochNum is always BlockNum/10, so a reader observing a mix of old and
+	// new field values would trip the consistency check below.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -189,6 +202,20 @@ func TestConcurrentPromMetricsPublicationAndRendering(t *testing.T) {
 				SlotNum:  i,
 				EpochNum: i / 10,
 			})
+		}
+	}()
+
+	// Consistency reader: deterministically checks the writer's invariant
+	// holds on every snapshot observed, regardless of race-detector mode.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			if m := promMetrics.Load(); m != nil {
+				if m.BlockNum != m.SlotNum || m.EpochNum != m.BlockNum/10 {
+					inconsistent.Store(true)
+				}
+			}
 		}
 	}()
 
@@ -212,4 +239,8 @@ func TestConcurrentPromMetricsPublicationAndRendering(t *testing.T) {
 	}
 
 	wg.Wait()
+
+	if inconsistent.Load() {
+		t.Fatal("observed a promMetrics snapshot with inconsistent fields, expected whole-struct replacement")
+	}
 }

--- a/health_test.go
+++ b/health_test.go
@@ -167,15 +167,17 @@ func TestGetPromMetricsAppliesResultExactlyOnce(t *testing.T) {
 //
 // The race detector alone would make this test a silent no-op under a plain
 // `go test ./...` (the CI workflow does not pass -race), so a consistency
-// reader also asserts, on every observed snapshot, that BlockNum, SlotNum,
-// and EpochNum still satisfy the writer's invariant. That fails
-// deterministically, with or without -race, if publication ever stopped
-// being a whole-struct replacement (for example a future change that
-// mutated fields on the shared struct in place, which could let a reader
-// observe some fields from one write and some from the next).
+// reader also asserts, on every test-produced snapshot, that BlockNum,
+// SlotNum, and EpochNum still satisfy the writer's invariant. That catches a
+// publication change that mutates fields on a shared struct in place, which
+// could let a reader observe some fields from one write and some from the
+// next.
 func TestConcurrentPromMetricsPublicationAndRendering(t *testing.T) {
 	originalPromMetrics := promMetrics.Load()
 	defer promMetrics.Store(originalPromMetrics)
+	// Seed a valid test snapshot so the reader cannot inspect an unrelated
+	// snapshot published by another test before this writer runs.
+	promMetrics.Store(&PromMetrics{})
 
 	// chainPaneSeverity consults the slot tip gap, which divides by the
 	// configured slot length; give it a non-zero value so this test
@@ -205,8 +207,8 @@ func TestConcurrentPromMetricsPublicationAndRendering(t *testing.T) {
 		}
 	}()
 
-	// Consistency reader: deterministically checks the writer's invariant
-	// holds on every snapshot observed, regardless of race-detector mode.
+	// Consistency reader checks the writer's invariant on every snapshot
+	// observed, regardless of race-detector mode.
 	wg.Add(1)
 	go func() {
 		defer wg.Done()

--- a/health_test.go
+++ b/health_test.go
@@ -1,0 +1,215 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/blinklabs-io/nview/internal/config"
+)
+
+// resetSubsystemFailuresForTest zeroes every subsystem's consecutive-failure
+// count and returns the prior values so a test can restore them.
+func resetSubsystemFailuresForTest() [healthSubsystemCount]uint32 {
+	var original [healthSubsystemCount]uint32
+	for i := range subsystemFailures {
+		original[i] = subsystemFailures[i].Load()
+		subsystemFailures[i].Store(0)
+	}
+	return original
+}
+
+func restoreSubsystemFailuresForTest(original [healthSubsystemCount]uint32) {
+	for i := range subsystemFailures {
+		subsystemFailures[i].Store(original[i])
+	}
+}
+
+// TestSubsystemFailuresAreIndependent proves that a success recorded for one
+// subsystem never clears another subsystem's consecutive-failure count. The
+// bug this guards against: a single shared failure counter meant a healthy
+// peer probe (or any unrelated renderer) could silently erase an ongoing
+// Prometheus scrape outage from the dashboard's health signal.
+func TestSubsystemFailuresAreIndependent(t *testing.T) {
+	original := resetSubsystemFailuresForTest()
+	defer restoreSubsystemFailuresForTest(original)
+
+	recordSubsystemFailure(healthSubsystemPrometheus)
+	recordSubsystemFailure(healthSubsystemPrometheus)
+	recordSubsystemFailure(healthSubsystemPrometheus)
+
+	if got := subsystemFailures[healthSubsystemPrometheus].Load(); got != 3 {
+		t.Fatalf("prometheus failure count = %d, expected 3", got)
+	}
+
+	// A success in an unrelated subsystem must not touch Prometheus's count.
+	recordSubsystemSuccess(healthSubsystemPeers)
+	recordSubsystemSuccess(healthSubsystemProcess)
+
+	if got := subsystemFailures[healthSubsystemPrometheus].Load(); got != 3 {
+		t.Fatalf(
+			"prometheus failure count changed to %d after an unrelated subsystem succeeded, expected 3",
+			got,
+		)
+	}
+	if got := subsystemFailures[healthSubsystemPeers].Load(); got != 0 {
+		t.Fatalf("peers failure count = %d, expected 0", got)
+	}
+
+	// Recovering the Prometheus subsystem itself must clear only its own
+	// count.
+	recordSubsystemFailure(healthSubsystemPeers)
+	recordSubsystemSuccess(healthSubsystemPrometheus)
+	if got := subsystemFailures[healthSubsystemPrometheus].Load(); got != 0 {
+		t.Fatalf("prometheus failure count = %d after its own success, expected 0", got)
+	}
+	if got := subsystemFailures[healthSubsystemPeers].Load(); got != 1 {
+		t.Fatalf("peers failure count = %d, expected 1 to remain untouched", got)
+	}
+}
+
+// TestFailCountReportsWorstSubsystem verifies the aggregate failCount used
+// for the dashboard health indicator and the connect-retry panic threshold
+// reports the worst consecutive-failure streak across all subsystems, not a
+// sum or a single subsystem's view.
+func TestFailCountReportsWorstSubsystem(t *testing.T) {
+	original := resetSubsystemFailuresForTest()
+	defer restoreSubsystemFailuresForTest(original)
+
+	if got := failCount(); got != 0 {
+		t.Fatalf("failCount() = %d, expected 0 with no failures", got)
+	}
+
+	recordSubsystemFailure(healthSubsystemProcess)
+	recordSubsystemFailure(healthSubsystemProcess)
+	recordSubsystemFailure(healthSubsystemPeers)
+
+	if got := failCount(); got != 2 {
+		t.Fatalf("failCount() = %d, expected 2 (the worst subsystem)", got)
+	}
+
+	recordSubsystemFailure(healthSubsystemPrometheus)
+	recordSubsystemFailure(healthSubsystemPrometheus)
+	recordSubsystemFailure(healthSubsystemPrometheus)
+	recordSubsystemFailure(healthSubsystemPrometheus)
+	recordSubsystemFailure(healthSubsystemPrometheus)
+
+	if got := failCount(); got != 5 {
+		t.Fatalf("failCount() = %d, expected 5 once Prometheus becomes the worst subsystem", got)
+	}
+
+	recordSubsystemSuccess(healthSubsystemPrometheus)
+	if got := failCount(); got != 2 {
+		t.Fatalf(
+			"failCount() = %d, expected 2 after Prometheus recovers, leaving process as the worst",
+			got,
+		)
+	}
+}
+
+// TestGetPromMetricsAppliesResultExactlyOnce guards against the historical
+// double-count bug: a single failed scrape attempt must move the Prometheus
+// subsystem's consecutive-failure count by exactly one, and a single
+// successful attempt must clear it, regardless of how many times the caller
+// inspects the error.
+func TestGetPromMetricsAppliesResultExactlyOnce(t *testing.T) {
+	original := resetSubsystemFailuresForTest()
+	defer restoreSubsystemFailuresForTest(original)
+
+	cfg := config.GetConfig()
+	originalHost := cfg.Prometheus.Host
+	originalPort := cfg.Prometheus.Port
+	originalTimeout := cfg.Prometheus.Timeout
+	defer func() {
+		cfg.Prometheus.Host = originalHost
+		cfg.Prometheus.Port = originalPort
+		cfg.Prometheus.Timeout = originalTimeout
+	}()
+	// Port 0 is never a listening Prometheus endpoint, so the request fails
+	// immediately instead of depending on network timing.
+	cfg.Prometheus.Host = "127.0.0.1"
+	cfg.Prometheus.Port = 0
+	cfg.Prometheus.Timeout = 1
+
+	ctx := context.Background()
+	if _, err := getPromMetrics(ctx); err == nil {
+		t.Fatal("expected getPromMetrics to fail against an unreachable endpoint")
+	}
+	if got := subsystemFailures[healthSubsystemPrometheus].Load(); got != 1 {
+		t.Fatalf(
+			"prometheus failure count = %d after one failed attempt, expected exactly 1",
+			got,
+		)
+	}
+}
+
+// TestConcurrentPromMetricsPublicationAndRendering exercises the scrape
+// goroutine's snapshot publication concurrently with renderer goroutines
+// reading it, under the race detector. Before promMetrics became an
+// atomic.Pointer[PromMetrics], this same access pattern (an unsynchronized
+// package-level *PromMetrics written by one goroutine and read by others)
+// raced. Run with `go test -race` to verify no race is reported.
+func TestConcurrentPromMetricsPublicationAndRendering(t *testing.T) {
+	originalPromMetrics := promMetrics.Load()
+	defer promMetrics.Store(originalPromMetrics)
+
+	// chainPaneSeverity consults the slot tip gap, which divides by the
+	// configured slot length; give it a non-zero value so this test
+	// exercises that path instead of tripping over unrelated config setup.
+	cfg := config.GetConfig()
+	originalSlotLength := cfg.Node.ShelleyGenesis.SlotLength
+	defer func() { cfg.Node.ShelleyGenesis.SlotLength = originalSlotLength }()
+	cfg.Node.ShelleyGenesis.SlotLength = 1000
+
+	const iterations = 200
+	var wg sync.WaitGroup
+
+	// Writer: mimics the scrape goroutine publishing a fresh, complete
+	// snapshot on every attempt.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := uint64(0); i < iterations; i++ {
+			promMetrics.Store(&PromMetrics{
+				BlockNum: i,
+				SlotNum:  i,
+				EpochNum: i / 10,
+			})
+		}
+	}()
+
+	// Readers: mimic renderer goroutines observing the snapshot mid-flight.
+	renderers := []func(){
+		func() { dashboardHealth() },
+		func() { currentNetworkName() },
+		func() { chainPaneSeverity() },
+		func() { blockPaneSeverity() },
+		func() { corePaneSeverity() },
+		func() { runtimePaneSeverity() },
+	}
+	for _, render := range renderers {
+		wg.Add(1)
+		go func(render func()) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				render()
+			}
+		}(render)
+	}
+
+	wg.Wait()
+}

--- a/main.go
+++ b/main.go
@@ -2826,6 +2826,7 @@ func main() {
 				}
 				continue
 			}
+			recordSubsystemSuccess(healthSubsystemPeers)
 			select {
 			case <-ctx.Done():
 				return

--- a/main.go
+++ b/main.go
@@ -644,7 +644,7 @@ func chainPaneSeverity() uiSeverity {
 	if promMetrics.SlotNum == 0 {
 		return uiSeverityMuted
 	}
-	_, severity := currentTipGap()
+	_, severity := currentTipGap(promMetrics)
 	return severity
 }
 
@@ -790,16 +790,15 @@ func dingoPanelTitle() string {
 	}
 }
 
-func currentTipGap() (uint64, uiSeverity) {
-	promMetrics := promMetrics.Load()
-	if promMetrics == nil || promMetrics.SlotNum == 0 {
+func currentTipGap(metrics *PromMetrics) (uint64, uiSeverity) {
+	if metrics == nil || metrics.SlotNum == 0 {
 		return 0, uiSeverityMuted
 	}
 	tipRef := getSlotTipRef()
-	if tipRef < promMetrics.SlotNum {
+	if tipRef < metrics.SlotNum {
 		return 0, uiSeverityOK
 	}
-	gap := tipRef - promMetrics.SlotNum
+	gap := tipRef - metrics.SlotNum
 	return gap, dingoTipGapSeverity(gap)
 }
 
@@ -864,8 +863,8 @@ func getOverviewText(ctx context.Context) string {
 		return sb.String()
 	}
 
-	tipGap, tipSeverity := currentTipGap()
-	epochProgress := float64(getEpochProgress())
+	tipGap, tipSeverity := currentTipGap(promMetrics)
+	epochProgress := float64(getEpochProgress(promMetrics))
 	fmt.Fprintf(&sb, " %s   %s   %s\n",
 		uiKV("Block", uiValue(strconv.FormatUint(promMetrics.BlockNum, 10))),
 		uiKV("Slot", uiValue(strconv.FormatUint(promMetrics.SlotNum, 10))),
@@ -877,7 +876,7 @@ func getOverviewText(ctx context.Context) string {
 	)
 	fmt.Fprintf(&sb, " %s   %s   %s\n",
 		uiPercentBar("Epoch", epochProgress, mithrilProgressSeverity(epochProgress), 20),
-		uiKVAligned(9, "Remaining", uiValue(formatEpochRemaining())),
+		uiKVAligned(9, "Remaining", uiValue(formatEpochRemaining(promMetrics))),
 		uiKVAligned(9, "Peers", peerStateSegmentBar(promMetrics, 12)),
 	)
 	if getEffectiveNodeBinary() == DINGO_BINARY {
@@ -910,7 +909,7 @@ func getOperatorFocusText(ctx context.Context) string {
 
 	var sb strings.Builder
 	sb.WriteString(uiSection("Node Signals"))
-	tipGap, tipSeverity := currentTipGap()
+	tipGap, tipSeverity := currentTipGap(promMetrics)
 	fmt.Fprintf(&sb, " %s   %s\n",
 		uiKV("Health", uiSeverityValue(dashboardHealthLabel(), dashboardHealthSeverity())),
 		uiKV(
@@ -1282,19 +1281,19 @@ func dingoConsoleTipGap(metrics *PromMetrics) (uint64, uiSeverity) {
 		metrics.DingoEpochLengthSlots > 0 {
 		return metrics.DingoTipGapSlots, dingoTipGapSeverity(metrics.DingoTipGapSlots)
 	}
-	return currentTipGap()
+	return currentTipGap(metrics)
 }
 
-func formatEpochSwitchTime() string {
-	switchTime, ok := currentEpochSwitchTime()
+func formatEpochSwitchTime(metrics *PromMetrics) string {
+	switchTime, ok := currentEpochSwitchTime(metrics)
 	if !ok {
 		return "n/a"
 	}
 	return switchTime.Format("2006-01-02 15:04:05 MST")
 }
 
-func formatEpochSwitchClock() string {
-	switchTime, ok := currentEpochSwitchTime()
+func formatEpochSwitchClock(metrics *PromMetrics) string {
+	switchTime, ok := currentEpochSwitchTime(metrics)
 	if !ok {
 		return "n/a"
 	}
@@ -1407,7 +1406,7 @@ func dingoConsoleHero(metrics *PromMetrics, width int) string {
 						uiUnit("/")+
 						uiValue(strconv.FormatUint(metrics.PeersEstablished, 10)),
 				),
-				dingoMetric("Remaining", uiValue(formatEpochRemaining())),
+				dingoMetric("Remaining", uiValue(formatEpochRemaining(metrics))),
 			),
 		},
 	)
@@ -1468,7 +1467,7 @@ func dingoConsoleDashboardCompact(metrics *PromMetrics, width int) string {
 					uiSeverityValue(strconv.FormatUint(tipGap, 10), tipSeverity)+uiUnit(" slots"),
 					tipSeverity,
 				),
-				dingoMetric("Remaining", uiValue(formatEpochRemaining())),
+				dingoMetric("Remaining", uiValue(formatEpochRemaining(metrics))),
 			),
 			dingoMetricRowColumns(
 				innerWidth,
@@ -1769,7 +1768,7 @@ func dingoConsoleChainLane(metrics *PromMetrics, width int) string {
 		epoch = currentEpoch
 	}
 	mempoolKBytes := metrics.MempoolBytes / 1024
-	epochProgress := float64(getEpochProgress())
+	epochProgress := float64(getEpochProgress(metrics))
 	progressSeverity := mithrilProgressSeverity(epochProgress)
 	innerWidth := dingoPanelInnerWidth(width)
 
@@ -1800,8 +1799,8 @@ func dingoConsoleChainLane(metrics *PromMetrics, width int) string {
 			dingoMetricRow(
 				innerWidth,
 				dingoMetric("Epoch No.", uiValue(strconv.FormatUint(epoch, 10))),
-				dingoMetric("Remaining", uiValue(formatEpochRemaining())),
-				dingoMetricSpan("Switch", uiValue(formatEpochSwitchTime()), 2),
+				dingoMetric("Remaining", uiValue(formatEpochRemaining(metrics))),
+				dingoMetricSpan("Switch", uiValue(formatEpochSwitchTime(metrics)), 2),
 			),
 			dingoMetricRow(
 				innerWidth,
@@ -1852,7 +1851,7 @@ func dingoConsoleChainCompact(metrics *PromMetrics, width int) string {
 			dingoMetricRowColumns(
 				innerWidth,
 				2,
-				dingoMetric("Remain", uiValue(formatEpochRemaining())),
+				dingoMetric("Remain", uiValue(formatEpochRemaining(metrics))),
 				dingoMetric(
 					"Mempool",
 					uiValue(strconv.FormatUint(metrics.MempoolTx, 10))+
@@ -3437,7 +3436,7 @@ func getMithrilOverlayText(width int) string {
 	m := promMetrics
 	innerWidth := dingoPanelInnerWidth(width)
 	tipGap, tipSeverity := dingoConsoleTipGap(m)
-	epochProgress := float64(getEpochProgress())
+	epochProgress := float64(getEpochProgress(m))
 	progressSeverity := mithrilProgressSeverity(epochProgress)
 
 	startedAgo := "n/a"
@@ -3493,8 +3492,8 @@ func getMithrilOverlayText(width int) string {
 					uiProgressBar(epochProgress, 34, progressSeverity),
 				2,
 			),
-			dingoMetric("Remaining", uiValue(formatEpochRemaining())),
-			dingoMetric("Switch", uiValue(formatEpochSwitchClock())),
+			dingoMetric("Remaining", uiValue(formatEpochRemaining(m))),
+			dingoMetric("Switch", uiValue(formatEpochSwitchClock(m))),
 		),
 	)
 
@@ -3719,22 +3718,21 @@ func getMithrilStats() string {
 	return sb.String()
 }
 
-func getEpochProgress() float32 {
+func getEpochProgress(metrics *PromMetrics) float32 {
 	cfg := config.GetConfig()
 	if cfg.Node.ShelleyTransEpoch < 0 {
 		return float32(0.0)
 	}
-	promMetrics := promMetrics.Load()
 	var epochProgress float32
-	if promMetrics == nil {
+	if metrics == nil {
 		epochProgress = float32(0.0)
 		// #nosec G115
-	} else if promMetrics.EpochNum >= uint64(cfg.Node.ShelleyTransEpoch) {
+	} else if metrics.EpochNum >= uint64(cfg.Node.ShelleyTransEpoch) {
 		if cfg.Node.ShelleyGenesis.EpochLength == 0 {
 			epochProgress = 0.0
 		} else {
 			epochProgress = float32(
-				(float32(promMetrics.SlotInEpoch) / float32(cfg.Node.ShelleyGenesis.EpochLength)) * 100,
+				(float32(metrics.SlotInEpoch) / float32(cfg.Node.ShelleyGenesis.EpochLength)) * 100,
 			)
 		}
 	} else {
@@ -3742,7 +3740,7 @@ func getEpochProgress() float32 {
 			epochProgress = 0.0
 		} else {
 			epochProgress = float32(
-				(float32(promMetrics.SlotInEpoch) / float32(cfg.Node.ByronGenesis.EpochLength)) * 100,
+				(float32(metrics.SlotInEpoch) / float32(cfg.Node.ByronGenesis.EpochLength)) * 100,
 			)
 		}
 	}
@@ -3760,14 +3758,13 @@ func currentEpochTimingForMetrics(cfg *config.Config, metrics *PromMetrics) (epo
 	return cfg.Node.ByronGenesis.EpochLength, cfg.Node.ByronGenesis.SlotLength, cfg.Node.ByronGenesis.EpochLength > 0 && cfg.Node.ByronGenesis.SlotLength > 0
 }
 
-func currentEpochSwitchTime() (time.Time, bool) {
+func currentEpochSwitchTime(metrics *PromMetrics) (time.Time, bool) {
 	cfg := config.GetConfig()
-	promMetrics := promMetrics.Load()
-	if promMetrics == nil || cfg.Node.ByronGenesis.StartTime == 0 {
+	if metrics == nil || cfg.Node.ByronGenesis.StartTime == 0 {
 		return time.Time{}, false
 	}
 
-	epoch := promMetrics.EpochNum
+	epoch := metrics.EpochNum
 	if cfg.Node.ShelleyTransEpoch >= 0 &&
 		epoch >= uint64(cfg.Node.ShelleyTransEpoch) {
 		if cfg.Node.ByronGenesis.EpochLength == 0 ||
@@ -3804,8 +3801,8 @@ func unixTimeFromUint64(seconds uint64) (time.Time, bool) {
 	return time.Unix(int64(seconds), 0), true //nolint:gosec // bounds checked above
 }
 
-func getEpochRemainingSeconds() (uint64, bool) {
-	if switchTime, ok := currentEpochSwitchTime(); ok {
+func getEpochRemainingSeconds(metrics *PromMetrics) (uint64, bool) {
+	if switchTime, ok := currentEpochSwitchTime(metrics); ok {
 		remaining := time.Until(switchTime)
 		if remaining <= 0 {
 			return 0, true
@@ -3813,7 +3810,6 @@ func getEpochRemainingSeconds() (uint64, bool) {
 		return uint64(remaining / time.Second), true
 	}
 
-	metrics := promMetrics.Load()
 	epochLength, slotLengthMs, ok := currentEpochTimingForMetrics(config.GetConfig(), metrics)
 	if !ok || metrics == nil {
 		return 0, false
@@ -3825,8 +3821,8 @@ func getEpochRemainingSeconds() (uint64, bool) {
 	return (remainingSlots * slotLengthMs) / 1000, true
 }
 
-func formatEpochRemaining() string {
-	remaining, ok := getEpochRemainingSeconds()
+func formatEpochRemaining(metrics *PromMetrics) string {
+	remaining, ok := getEpochRemainingSeconds(metrics)
 	if !ok {
 		return "n/a"
 	}
@@ -3840,14 +3836,15 @@ func getEpochText(ctx context.Context) string {
 	default:
 	}
 
+	promMetrics := promMetrics.Load()
 	var sb strings.Builder
 
-	epochProgress := getEpochProgress()
+	epochProgress := getEpochProgress(promMetrics)
 	severity := mithrilProgressSeverity(float64(epochProgress))
 
 	fmt.Fprintf(&sb, " %s   %s\n",
 		uiKV("Epoch", uiValue(strconv.FormatUint(currentEpoch, 10))),
-		uiKV("Remaining", uiValue(formatEpochRemaining())),
+		uiKV("Remaining", uiValue(formatEpochRemaining(promMetrics))),
 	)
 	fmt.Fprintf(&sb, " %s\n",
 		uiPercentBar("Progress", float64(epochProgress), severity, 50),

--- a/main.go
+++ b/main.go
@@ -284,9 +284,6 @@ var blockText, chainText, coreText, connectionText, dingoConsoleText, dingoText,
 // Metrics variables
 var processMetrics *process.Process
 
-// Track our failures
-var failCount atomic.Uint32
-
 func getActiveSecondaryView() secondaryView {
 	return secondaryView(activeSecondary.Load())
 }
@@ -383,6 +380,7 @@ func newPeerOverlayPrimitive(width, rows int) tview.Primitive {
 }
 
 func currentNetworkName() string {
+	promMetrics := promMetrics.Load()
 	if getEffectiveNodeBinary() == DINGO_BINARY && promMetrics != nil {
 		if network := strings.TrimSpace(promMetrics.Network); network != "" {
 			return formatNetworkName(network)
@@ -418,14 +416,14 @@ func visualModeName(mode terminalVisualMode) string {
 }
 
 func dashboardHealth() (string, uiSeverity) {
-	failures := failCount.Load()
+	failures := failCount()
 	if failures >= 5 {
 		return "degraded", uiSeverityCritical
 	}
 	if failures > 0 {
 		return "retrying", uiSeverityWarn
 	}
-	if promMetrics == nil {
+	if promMetrics.Load() == nil {
 		return "waiting", uiSeverityMuted
 	}
 	return "online", uiSeverityOK
@@ -639,6 +637,7 @@ func dashboardHealthSeverity() uiSeverity {
 }
 
 func chainPaneSeverity() uiSeverity {
+	promMetrics := promMetrics.Load()
 	if promMetrics == nil {
 		return uiSeverityMuted
 	}
@@ -650,6 +649,7 @@ func chainPaneSeverity() uiSeverity {
 }
 
 func blockPaneSeverity() uiSeverity {
+	promMetrics := promMetrics.Load()
 	if promMetrics == nil {
 		return uiSeverityMuted
 	}
@@ -663,6 +663,7 @@ func blockPaneSeverity() uiSeverity {
 }
 
 func activityPaneSeverity() uiSeverity {
+	promMetrics := promMetrics.Load()
 	if isMithrilSyncActive() {
 		if promMetrics == nil {
 			return uiSeverityMuted
@@ -679,6 +680,7 @@ func activityPaneSeverity() uiSeverity {
 }
 
 func corePaneSeverity() uiSeverity {
+	promMetrics := promMetrics.Load()
 	if promMetrics == nil || !hasForgeMetrics(promMetrics) {
 		return uiSeverityMuted
 	}
@@ -701,6 +703,7 @@ func corePaneSeverity() uiSeverity {
 }
 
 func runtimePaneSeverity() uiSeverity {
+	promMetrics := promMetrics.Load()
 	if promMetrics == nil {
 		return uiSeverityMuted
 	}
@@ -728,6 +731,7 @@ func dingoPaneSeverity() uiSeverity {
 	if !dashboardShowsDingoSystems() {
 		return dashboardHealthSeverity()
 	}
+	promMetrics := promMetrics.Load()
 	if promMetrics == nil {
 		return uiSeverityMuted
 	}
@@ -744,6 +748,7 @@ func dingoPaneSeverity() uiSeverity {
 }
 
 func peerPaneSeverity() uiSeverity {
+	promMetrics := promMetrics.Load()
 	peersFilteredMu.RLock()
 	peerCount := len(peersFiltered)
 	peersFilteredMu.RUnlock()
@@ -786,6 +791,7 @@ func dingoPanelTitle() string {
 }
 
 func currentTipGap() (uint64, uiSeverity) {
+	promMetrics := promMetrics.Load()
 	if promMetrics == nil || promMetrics.SlotNum == 0 {
 		return 0, uiSeverityMuted
 	}
@@ -842,6 +848,7 @@ func getOverviewText(ctx context.Context) string {
 	}
 
 	healthLabel, healthSeverity := dashboardHealth()
+	promMetrics := promMetrics.Load()
 	var sb strings.Builder
 	fmt.Fprintf(&sb, " %s   %s   %s   %s\n",
 		uiPill("impl", getEffectiveNodeBinary(), uiSeverityNeutral),
@@ -896,6 +903,7 @@ func getOperatorFocusText(ctx context.Context) string {
 		return ""
 	default:
 	}
+	promMetrics := promMetrics.Load()
 	if promMetrics == nil {
 		return " " + uiMuted("waiting for metrics") + "\n"
 	}
@@ -1302,6 +1310,7 @@ func getDingoConsoleText(ctx context.Context) string {
 
 	cols, rows := dashboardTerminalSize()
 	width := dashboardContentWidth()
+	promMetrics := promMetrics.Load()
 	if promMetrics == nil {
 		return fmt.Sprintf(
 			"\n %s  %s\n",
@@ -2705,7 +2714,6 @@ func main() {
 			prom, err := getPromMetrics(ctx)
 			if err != nil && prom != nil {
 				logger.Warn("Failed to fetch Prometheus metrics", "error", err)
-				failCount.Add(1)
 				select {
 				case <-ctx.Done():
 					return
@@ -2713,10 +2721,9 @@ func main() {
 				}
 				continue
 			} else if prom == nil {
-				if promMetrics == nil {
-					promMetrics = &PromMetrics{}
+				if promMetrics.Load() == nil {
+					promMetrics.Store(&PromMetrics{})
 				}
-				failCount.Add(1)
 				select {
 				case <-ctx.Done():
 					return
@@ -2739,7 +2746,7 @@ func main() {
 				}
 			}
 			applyDefaultSecondaryView()
-			promMetrics = prom
+			promMetrics.Store(prom)
 			updateMithrilView()
 			select {
 			case <-ctx.Done():
@@ -2762,7 +2769,7 @@ func main() {
 			}
 			proc, err := getProcessMetrics(ctx)
 			if err != nil {
-				failCount.Add(1)
+				recordSubsystemFailure(healthSubsystemProcess)
 				select {
 				case <-ctx.Done():
 					return
@@ -2771,6 +2778,7 @@ func main() {
 				continue
 			}
 			processMetrics = proc
+			recordSubsystemSuccess(healthSubsystemProcess)
 			select {
 			case <-ctx.Done():
 				return
@@ -2810,7 +2818,7 @@ func main() {
 			err := filterPeers(ctx)
 			if err != nil {
 				logger.Warn("Failed to filter peers", "error", err)
-				failCount.Add(1)
+				recordSubsystemFailure(healthSubsystemPeers)
 				select {
 				case <-ctx.Done():
 					return
@@ -2958,11 +2966,11 @@ func main() {
 				return
 			default:
 			}
-			if failCount.Load() >= cfg.App.Retries {
+			if failCount() >= cfg.App.Retries {
 				panic(
 					fmt.Errorf(
 						"COULD NOT CONNECT TO A RUNNING INSTANCE, %d FAILED ATTEMPTS IN A ROW",
-						failCount.Load(),
+						failCount(),
 					),
 				)
 			}
@@ -3171,6 +3179,7 @@ func formatSeverityPercentRatio(value uint64, percent float32, severity uiSeveri
 }
 
 func getDingoStats() string {
+	promMetrics := promMetrics.Load()
 	if promMetrics == nil {
 		return ""
 	}
@@ -3345,6 +3354,7 @@ func getDingoStats() string {
 }
 
 func isMithrilSyncActive() bool {
+	promMetrics := promMetrics.Load()
 	if promMetrics == nil {
 		return false
 	}
@@ -3410,6 +3420,7 @@ func updateMithrilView() {
 }
 
 func getMithrilOverlayText(width int) string {
+	promMetrics := promMetrics.Load()
 	if promMetrics == nil {
 		return ""
 	}
@@ -3525,6 +3536,7 @@ func formatMithrilProgressLine(
 }
 
 func getMithrilStats() string {
+	promMetrics := promMetrics.Load()
 	if promMetrics == nil {
 		return ""
 	}
@@ -3702,6 +3714,7 @@ func getEpochProgress() float32 {
 	if cfg.Node.ShelleyTransEpoch < 0 {
 		return float32(0.0)
 	}
+	promMetrics := promMetrics.Load()
 	var epochProgress float32
 	if promMetrics == nil {
 		epochProgress = float32(0.0)
@@ -3728,6 +3741,7 @@ func getEpochProgress() float32 {
 
 func currentEpochTiming() (epochLengthSlots uint64, slotLengthMs uint64, ok bool) {
 	cfg := config.GetConfig()
+	promMetrics := promMetrics.Load()
 	if promMetrics == nil {
 		return 0, 0, false
 	}
@@ -3740,6 +3754,7 @@ func currentEpochTiming() (epochLengthSlots uint64, slotLengthMs uint64, ok bool
 
 func currentEpochSwitchTime() (time.Time, bool) {
 	cfg := config.GetConfig()
+	promMetrics := promMetrics.Load()
 	if promMetrics == nil || cfg.Node.ByronGenesis.StartTime == 0 {
 		return time.Time{}, false
 	}
@@ -3791,6 +3806,7 @@ func getEpochRemainingSeconds() (uint64, bool) {
 	}
 
 	epochLength, slotLengthMs, ok := currentEpochTiming()
+	promMetrics := promMetrics.Load()
 	if !ok || promMetrics == nil {
 		return 0, false
 	}
@@ -3838,6 +3854,7 @@ func getChainText(ctx context.Context) string {
 	default:
 	}
 
+	promMetrics := promMetrics.Load()
 	if promMetrics == nil {
 		return chainText
 	}
@@ -3896,6 +3913,7 @@ func getChainText(ctx context.Context) string {
 func getConnectionText(ctx context.Context) string {
 	cfg := config.GetConfig()
 	var sb strings.Builder
+	promMetrics := promMetrics.Load()
 
 	if p2p {
 		if promMetrics == nil {
@@ -3962,6 +3980,7 @@ func getCoreText(ctx context.Context) string {
 	default:
 	}
 
+	promMetrics := promMetrics.Load()
 	if promMetrics == nil {
 		return coreText
 	}
@@ -4054,7 +4073,6 @@ func getCoreText(ctx context.Context) string {
 	} else {
 		fmt.Fprintf(&sb, " %s\n", uiMuted("observing only"))
 	}
-	failCount.Store(0)
 	return sb.String()
 }
 
@@ -4065,11 +4083,11 @@ func getBlockText(ctx context.Context) string {
 	default:
 	}
 
+	promMetrics := promMetrics.Load()
 	if promMetrics == nil {
 		return blockText
 	}
 	if getEffectiveNodeBinary() == DINGO_BINARY && hasDingoPropagationMetrics(promMetrics) {
-		failCount.Store(0)
 		return getDingoPropagationText()
 	}
 
@@ -4079,12 +4097,10 @@ func getBlockText(ctx context.Context) string {
 	// Get our terminal size
 	fd := os.Stdout.Fd()
 	if fd > math.MaxInt {
-		failCount.Add(1)
 		return "ERROR: invalid file descriptor"
 	}
 	tcols, tlines, err := terminal.GetSize(int(fd)) //nolint:gosec // fd validated above
 	if err != nil {
-		failCount.Add(1)
 		return fmt.Sprintf("ERROR: %v", err)
 	}
 	// Validate size
@@ -4143,7 +4159,6 @@ func getBlockText(ctx context.Context) string {
 		uiMuted("1s 3s 5s"),
 	)
 
-	failCount.Store(0)
 	return sb.String()
 }
 
@@ -4163,6 +4178,7 @@ func hasDingoPropagationMetrics(metrics *PromMetrics) bool {
 }
 
 func getDingoPropagationText() string {
+	promMetrics := promMetrics.Load()
 	if promMetrics == nil {
 		return ""
 	}
@@ -4305,6 +4321,7 @@ func formatBlockPropagationPercent(value float64) string {
 }
 
 func currentNodeVersionInfo() (string, string) {
+	promMetrics := promMetrics.Load()
 	if promMetrics != nil && getEffectiveNodeBinary() == DINGO_BINARY {
 		version := strings.TrimSpace(promMetrics.DingoBuildVersion)
 		revision := strings.TrimSpace(promMetrics.DingoBuildCommit)
@@ -4377,6 +4394,7 @@ func getPeerText(ctx context.Context) string {
 	default:
 	}
 
+	promMetrics := promMetrics.Load()
 	var sb strings.Builder
 
 	// Style / UI
@@ -4547,11 +4565,11 @@ func getPeerText(ctx context.Context) string {
 	}
 	sb.WriteString("[white]\n")
 
-	failCount.Store(0)
 	return sb.String()
 }
 
 func getResourceText(ctx context.Context) string {
+	promMetrics := promMetrics.Load()
 	if processMetrics == nil || promMetrics == nil {
 		return resourceText
 	}
@@ -4565,12 +4583,10 @@ func getResourceText(ctx context.Context) string {
 	if processMetrics != nil && processMetrics.Pid != 0 {
 		cpuPercent, err = processMetrics.CPUPercentWithContext(ctx)
 		if err != nil {
-			failCount.Add(1)
 			return fmt.Sprintf("cannot parse CPU usage: %s", err)
 		}
 		processMemory, err = processMetrics.MemoryInfoWithContext(ctx)
 		if err != nil {
-			failCount.Add(1)
 			return fmt.Sprintf("cannot parse memory usage: %s", err)
 		}
 		rss = processMemory.RSS

--- a/main.go
+++ b/main.go
@@ -2777,6 +2777,15 @@ func main() {
 				}
 				continue
 			}
+			if proc == nil || proc.Pid <= 0 {
+				recordSubsystemFailure(healthSubsystemProcess)
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(time.Second * 1):
+				}
+				continue
+			}
 			processMetrics = proc
 			recordSubsystemSuccess(healthSubsystemProcess)
 			select {
@@ -3740,14 +3749,12 @@ func getEpochProgress() float32 {
 	return epochProgress
 }
 
-func currentEpochTiming() (epochLengthSlots uint64, slotLengthMs uint64, ok bool) {
-	cfg := config.GetConfig()
-	promMetrics := promMetrics.Load()
-	if promMetrics == nil {
+func currentEpochTimingForMetrics(cfg *config.Config, metrics *PromMetrics) (epochLengthSlots uint64, slotLengthMs uint64, ok bool) {
+	if metrics == nil {
 		return 0, 0, false
 	}
 	if cfg.Node.ShelleyTransEpoch >= 0 &&
-		promMetrics.EpochNum >= uint64(cfg.Node.ShelleyTransEpoch) {
+		metrics.EpochNum >= uint64(cfg.Node.ShelleyTransEpoch) {
 		return cfg.Node.ShelleyGenesis.EpochLength, cfg.Node.ShelleyGenesis.SlotLength, cfg.Node.ShelleyGenesis.EpochLength > 0 && cfg.Node.ShelleyGenesis.SlotLength > 0
 	}
 	return cfg.Node.ByronGenesis.EpochLength, cfg.Node.ByronGenesis.SlotLength, cfg.Node.ByronGenesis.EpochLength > 0 && cfg.Node.ByronGenesis.SlotLength > 0
@@ -3806,15 +3813,15 @@ func getEpochRemainingSeconds() (uint64, bool) {
 		return uint64(remaining / time.Second), true
 	}
 
-	epochLength, slotLengthMs, ok := currentEpochTiming()
-	promMetrics := promMetrics.Load()
-	if !ok || promMetrics == nil {
+	metrics := promMetrics.Load()
+	epochLength, slotLengthMs, ok := currentEpochTimingForMetrics(config.GetConfig(), metrics)
+	if !ok || metrics == nil {
 		return 0, false
 	}
-	if promMetrics.SlotInEpoch >= epochLength {
+	if metrics.SlotInEpoch >= epochLength {
 		return 0, true
 	}
-	remainingSlots := epochLength - promMetrics.SlotInEpoch
+	remainingSlots := epochLength - metrics.SlotInEpoch
 	return (remainingSlots * slotLengthMs) / 1000, true
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -639,9 +639,9 @@ func TestGetEpochProgress(t *testing.T) {
 			cfg.Node.ByronGenesis.EpochLength = tt.epochLength
 
 			// Set global promMetrics
-			originalPromMetrics := promMetrics
-			promMetrics = tt.promMetrics
-			defer func() { promMetrics = originalPromMetrics }()
+			originalPromMetrics := promMetrics.Load()
+			promMetrics.Store(tt.promMetrics)
+			defer func() { promMetrics.Store(originalPromMetrics) }()
 
 			result := getEpochProgress()
 			if result != tt.expected {
@@ -688,12 +688,12 @@ func TestGetEpochText(t *testing.T) {
 			cfg.Node.ByronGenesis.EpochLength = 216000
 
 			// Set globals
-			originalPromMetrics := promMetrics
+			originalPromMetrics := promMetrics.Load()
 			originalCurrentEpoch := currentEpoch
-			promMetrics = tt.promMetrics
+			promMetrics.Store(tt.promMetrics)
 			currentEpoch = tt.currentEpoch
 			defer func() {
-				promMetrics = originalPromMetrics
+				promMetrics.Store(originalPromMetrics)
 				currentEpoch = originalCurrentEpoch
 			}()
 
@@ -718,7 +718,7 @@ func TestFormatEpochRemaining(t *testing.T) {
 	originalByronStartTime := cfg.Node.ByronGenesis.StartTime
 	originalByronEpochLength := cfg.Node.ByronGenesis.EpochLength
 	originalByronSlotLength := cfg.Node.ByronGenesis.SlotLength
-	originalPromMetrics := promMetrics
+	originalPromMetrics := promMetrics.Load()
 	defer func() {
 		cfg.Node.ShelleyTransEpoch = originalShelleyTransEpoch
 		cfg.Node.ShelleyGenesis.EpochLength = originalShelleyEpochLength
@@ -726,7 +726,7 @@ func TestFormatEpochRemaining(t *testing.T) {
 		cfg.Node.ByronGenesis.StartTime = originalByronStartTime
 		cfg.Node.ByronGenesis.EpochLength = originalByronEpochLength
 		cfg.Node.ByronGenesis.SlotLength = originalByronSlotLength
-		promMetrics = originalPromMetrics
+		promMetrics.Store(originalPromMetrics)
 	}()
 
 	cfg.Node.ShelleyTransEpoch = 0
@@ -735,10 +735,10 @@ func TestFormatEpochRemaining(t *testing.T) {
 	cfg.Node.ByronGenesis.StartTime = uint64(time.Now().Unix()) - 1040
 	cfg.Node.ByronGenesis.EpochLength = 100
 	cfg.Node.ByronGenesis.SlotLength = 1000
-	promMetrics = &PromMetrics{
+	promMetrics.Store(&PromMetrics{
 		EpochNum:    10,
 		SlotInEpoch: 40,
-	}
+	})
 
 	remaining, ok := getEpochRemainingSeconds()
 	if !ok {
@@ -920,18 +920,25 @@ func TestDingoSeverityThresholds(t *testing.T) {
 }
 
 func TestDashboardPaneSeverities(t *testing.T) {
-	originalPromMetrics := promMetrics
+	originalPromMetrics := promMetrics.Load()
 	originalRole := role
-	originalFailCount := failCount.Load()
+	var originalFailures [healthSubsystemCount]uint32
+	for i := range subsystemFailures {
+		originalFailures[i] = subsystemFailures[i].Load()
+	}
 	defer func() {
-		promMetrics = originalPromMetrics
+		promMetrics.Store(originalPromMetrics)
 		role = originalRole
-		failCount.Store(originalFailCount)
+		for i := range subsystemFailures {
+			subsystemFailures[i].Store(originalFailures[i])
+		}
 	}()
 
-	failCount.Store(0)
+	for i := range subsystemFailures {
+		subsystemFailures[i].Store(0)
+	}
 	role = "Core"
-	promMetrics = &PromMetrics{
+	promMetrics.Store(&PromMetrics{
 		SlotNum:      90,
 		BlockDelay:   5,
 		BlocksLate:   1,
@@ -942,7 +949,7 @@ func TestDashboardPaneSeverities(t *testing.T) {
 		SlotInEpoch:  90,
 		EpochNum:     1,
 		BlocksServed: 10,
-	}
+	})
 
 	cfg := config.GetConfig()
 	originalShelleyTransEpoch := cfg.Node.ShelleyTransEpoch
@@ -964,11 +971,11 @@ func TestDashboardPaneSeverities(t *testing.T) {
 		t.Errorf("corePaneSeverity() = %d, expected %d", got, uiSeverityCritical)
 	}
 
-	failCount.Store(1)
+	subsystemFailures[healthSubsystemPrometheus].Store(1)
 	if _, got := dashboardHealth(); got != uiSeverityWarn {
 		t.Errorf("dashboardHealth severity = %d, expected %d", got, uiSeverityWarn)
 	}
-	failCount.Store(5)
+	subsystemFailures[healthSubsystemPrometheus].Store(5)
 	if _, got := dashboardHealth(); got != uiSeverityCritical {
 		t.Errorf("dashboardHealth severity = %d, expected %d", got, uiSeverityCritical)
 	}
@@ -1072,16 +1079,16 @@ func TestGetBlockTextRendersDingoProtocolPropagation(t *testing.T) {
 	cfg := config.GetConfig()
 	originalBinary := cfg.Node.Binary
 	originalDetectedBinary, _ := detectedNodeBinary.Load().(string)
-	originalPromMetrics := promMetrics
+	originalPromMetrics := promMetrics.Load()
 	defer func() {
 		cfg.Node.Binary = originalBinary
 		detectedNodeBinary.Store(originalDetectedBinary)
-		promMetrics = originalPromMetrics
+		promMetrics.Store(originalPromMetrics)
 	}()
 
 	cfg.Node.Binary = ""
 	detectedNodeBinary.Store(DINGO_BINARY)
-	promMetrics = &PromMetrics{
+	promMetrics.Store(&PromMetrics{
 		DingoProtocolBlockfetchMessages: 123,
 		DingoProtocolChainsyncMessages:  456,
 		DingoProtocolKeepaliveMessages:  7,
@@ -1093,7 +1100,7 @@ func TestGetBlockTextRendersDingoProtocolPropagation(t *testing.T) {
 		DingoBlockfetchGateDispatched:   3,
 		DingoBlockfetchGateSkippedFast:  8,
 		DingoBlockfetchGateSkippedPeer:  2,
-	}
+	})
 
 	result := getBlockText(context.Background())
 	for _, expected := range []string{
@@ -1117,7 +1124,7 @@ func TestGetDingoConsoleTextRendersUnboxedLanes(t *testing.T) {
 	cfg := config.GetConfig()
 	originalBinary := cfg.Node.Binary
 	originalDetectedBinary, _ := detectedNodeBinary.Load().(string)
-	originalPromMetrics := promMetrics
+	originalPromMetrics := promMetrics.Load()
 	originalCurrentEpoch := currentEpoch
 	originalRole := role
 	originalShelleyTransEpoch := cfg.Node.ShelleyTransEpoch
@@ -1139,7 +1146,7 @@ func TestGetDingoConsoleTextRendersUnboxedLanes(t *testing.T) {
 		cfg.Node.ByronGenesis.EpochLength = originalByronEpochLength
 		cfg.Node.ByronGenesis.SlotLength = originalByronSlotLength
 		detectedNodeBinary.Store(originalDetectedBinary)
-		promMetrics = originalPromMetrics
+		promMetrics.Store(originalPromMetrics)
 		currentEpoch = originalCurrentEpoch
 		role = originalRole
 		peersFilteredMu.Lock()
@@ -1159,7 +1166,7 @@ func TestGetDingoConsoleTextRendersUnboxedLanes(t *testing.T) {
 	detectedNodeBinary.Store(DINGO_BINARY)
 	currentEpoch = 1339
 	role = "Relay"
-	promMetrics = &PromMetrics{
+	promMetrics.Store(&PromMetrics{
 		Network:                         "preview",
 		DingoBuildVersion:               "v0.57.0",
 		DingoBuildCommit:                "62809b98",
@@ -1212,7 +1219,7 @@ func TestGetDingoConsoleTextRendersUnboxedLanes(t *testing.T) {
 		DingoStakeSnapshotPoolCount:     658,
 		DingoStakeSnapshotActiveStake:   1496610126371652,
 		LeiosMetrics:                    map[string]float64{"dingo_leios_blocks_total": 2},
-	}
+	})
 	peersFilteredMu.Lock()
 	peersFiltered = []string{"1.2.3.4:3001"}
 	peersFilteredMu.Unlock()
@@ -1325,7 +1332,7 @@ func TestGetDingoConsoleTextKeepsDingoViewDuringMithrilSync(t *testing.T) {
 	cfg := config.GetConfig()
 	originalBinary := cfg.Node.Binary
 	originalDetectedBinary, _ := detectedNodeBinary.Load().(string)
-	originalPromMetrics := promMetrics
+	originalPromMetrics := promMetrics.Load()
 	originalCurrentEpoch := currentEpoch
 	originalRole := role
 	originalShelleyTransEpoch := cfg.Node.ShelleyTransEpoch
@@ -1341,7 +1348,7 @@ func TestGetDingoConsoleTextKeepsDingoViewDuringMithrilSync(t *testing.T) {
 		cfg.Node.ByronGenesis.EpochLength = originalByronEpochLength
 		cfg.Node.ByronGenesis.SlotLength = originalByronSlotLength
 		detectedNodeBinary.Store(originalDetectedBinary)
-		promMetrics = originalPromMetrics
+		promMetrics.Store(originalPromMetrics)
 		currentEpoch = originalCurrentEpoch
 		role = originalRole
 	}()
@@ -1355,7 +1362,7 @@ func TestGetDingoConsoleTextKeepsDingoViewDuringMithrilSync(t *testing.T) {
 	detectedNodeBinary.Store(DINGO_BINARY)
 	currentEpoch = 42
 	role = "Relay"
-	promMetrics = &PromMetrics{
+	promMetrics.Store(&PromMetrics{
 		Network:                         "preview",
 		BlockNum:                        1000,
 		SlotNum:                         2000,
@@ -1372,7 +1379,7 @@ func TestGetDingoConsoleTextKeepsDingoViewDuringMithrilSync(t *testing.T) {
 		MithrilSyncLedgerImportCurrent:  25,
 		MithrilSyncLedgerImportTotal:    100,
 		MithrilSyncSnapshotSize:         1024,
-	}
+	})
 
 	result := getDingoConsoleText(context.Background())
 	for _, expected := range []string{
@@ -1447,19 +1454,19 @@ func TestCurrentNetworkNamePrefersDingoMetricLabel(t *testing.T) {
 	originalNodeNetwork := cfg.Node.Network
 	originalBinary := cfg.Node.Binary
 	originalDetectedBinary, _ := detectedNodeBinary.Load().(string)
-	originalPromMetrics := promMetrics
+	originalPromMetrics := promMetrics.Load()
 	defer func() {
 		cfg.App.Network = originalAppNetwork
 		cfg.Node.Network = originalNodeNetwork
 		cfg.Node.Binary = originalBinary
 		detectedNodeBinary.Store(originalDetectedBinary)
-		promMetrics = originalPromMetrics
+		promMetrics.Store(originalPromMetrics)
 	}()
 
 	cfg.App.Network = ""
 	cfg.Node.Network = "mainnet"
 	cfg.Node.Binary = ""
-	promMetrics = &PromMetrics{Network: "preview"}
+	promMetrics.Store(&PromMetrics{Network: "preview"})
 
 	detectedNodeBinary.Store(DINGO_BINARY)
 	if got := currentNetworkName(); got != "Preview" {
@@ -1476,19 +1483,19 @@ func TestCurrentNodeVersionInfoPrefersDingoBuildInfo(t *testing.T) {
 	cfg := config.GetConfig()
 	originalBinary := cfg.Node.Binary
 	originalDetectedBinary, _ := detectedNodeBinary.Load().(string)
-	originalPromMetrics := promMetrics
+	originalPromMetrics := promMetrics.Load()
 	defer func() {
 		cfg.Node.Binary = originalBinary
 		detectedNodeBinary.Store(originalDetectedBinary)
-		promMetrics = originalPromMetrics
+		promMetrics.Store(originalPromMetrics)
 	}()
 
 	cfg.Node.Binary = ""
 	detectedNodeBinary.Store(DINGO_BINARY)
-	promMetrics = &PromMetrics{
+	promMetrics.Store(&PromMetrics{
 		DingoBuildVersion: "v0.57.0 (commit 62809b98)",
 		DingoBuildCommit:  "62809b98abcdef",
-	}
+	})
 
 	version, revision := currentNodeVersionInfo()
 	if version != "v0.57.0" {
@@ -1585,14 +1592,14 @@ func TestApplyDefaultSecondaryView(t *testing.T) {
 // TestGetDingoStatsRendersDiagnostics verifies the diagnostics pane renders
 // Dingo-native values plus derived cache ratios and event/cold-extract rates.
 func TestGetDingoStatsRendersDiagnostics(t *testing.T) {
-	originalPromMetrics := promMetrics
+	originalPromMetrics := promMetrics.Load()
 	originalLastDingoSample := lastDingoSample
 	originalLastDingoSampleAt := lastDingoSampleAt
 	originalLastDingoRateBase := lastDingoRateBase
 	originalLastDingoRateBaseAt := lastDingoRateBaseAt
 	originalLastDingoSampleSrc := lastDingoSampleSrc
 	defer func() {
-		promMetrics = originalPromMetrics
+		promMetrics.Store(originalPromMetrics)
 		lastDingoSample = originalLastDingoSample
 		lastDingoSampleAt = originalLastDingoSampleAt
 		lastDingoRateBase = originalLastDingoRateBase
@@ -1615,7 +1622,7 @@ func TestGetDingoStatsRendersDiagnostics(t *testing.T) {
 		EventDeliveryTimeouts:  2,
 	}
 	lastDingoSampleAt = time.Now().Add(-10 * time.Second)
-	promMetrics = &PromMetrics{
+	promMetrics.Store(&PromMetrics{
 		DingoDbSizeBytes:              BytesInGigabyte,
 		DingoDbBlobSizeBytes:          512 * 1024 * 1024,
 		DingoDbMetadataSizeBytes:      512 * 1024 * 1024,
@@ -1654,7 +1661,7 @@ func TestGetDingoStatsRendersDiagnostics(t *testing.T) {
 		GoThreads:                     22,
 		ProcessOpenFDs:                965,
 		ProcessMaxFDs:                 122880,
-	}
+	})
 
 	result := getDingoStats()
 	expectedParts := []string{
@@ -1709,14 +1716,14 @@ func TestGetDingoStatsRendersDiagnostics(t *testing.T) {
 }
 
 func TestGetDingoStatsFirstSampleShowsUnavailableDeltas(t *testing.T) {
-	originalPromMetrics := promMetrics
+	originalPromMetrics := promMetrics.Load()
 	originalLastDingoSample := lastDingoSample
 	originalLastDingoSampleAt := lastDingoSampleAt
 	originalLastDingoRateBase := lastDingoRateBase
 	originalLastDingoRateBaseAt := lastDingoRateBaseAt
 	originalLastDingoSampleSrc := lastDingoSampleSrc
 	defer func() {
-		promMetrics = originalPromMetrics
+		promMetrics.Store(originalPromMetrics)
 		lastDingoSample = originalLastDingoSample
 		lastDingoSampleAt = originalLastDingoSampleAt
 		lastDingoRateBase = originalLastDingoRateBase
@@ -1729,14 +1736,14 @@ func TestGetDingoStatsFirstSampleShowsUnavailableDeltas(t *testing.T) {
 	lastDingoRateBase = nil
 	lastDingoRateBaseAt = time.Time{}
 	lastDingoSampleSrc = nil
-	promMetrics = &PromMetrics{
+	promMetrics.Store(&PromMetrics{
 		DingoCacheUtxoHotHits:  100,
 		DingoCacheTxHotHits:    100,
 		DingoCacheBlockLruHits: 100,
 		DingoCacheColdExtract:  100,
 		EventDeliveryErrors:    100,
 		EventDeliveryTimeouts:  100,
-	}
+	})
 
 	result := getDingoStats()
 	expectedParts := []string{
@@ -1758,10 +1765,10 @@ func TestGetDingoStatsFirstSampleShowsUnavailableDeltas(t *testing.T) {
 // TestGetMithrilStatsRendersView verifies the Mithril sync pane renders all
 // key fields including progress bars and error highlighting.
 func TestGetMithrilStatsRendersView(t *testing.T) {
-	originalPromMetrics := promMetrics
-	defer func() { promMetrics = originalPromMetrics }()
+	originalPromMetrics := promMetrics.Load()
+	defer func() { promMetrics.Store(originalPromMetrics) }()
 
-	promMetrics = &PromMetrics{
+	promMetrics.Store(&PromMetrics{
 		MithrilSyncCompleted:             0,
 		MithrilSyncStartedAt:             1700000000,
 		MithrilSyncErrorsTotal:           1,
@@ -1788,7 +1795,7 @@ func TestGetMithrilStatsRendersView(t *testing.T) {
 		MithrilSyncImmutableTipSlot:       112985271,
 		MithrilSyncGapBlocks:              1200,
 		MithrilPhaseImmutable:             1,
-	}
+	})
 
 	result := getMithrilStats()
 
@@ -1833,10 +1840,10 @@ func TestGetMithrilStatsRendersView(t *testing.T) {
 }
 
 func TestGetMithrilStatsNilMetrics(t *testing.T) {
-	originalPromMetrics := promMetrics
-	defer func() { promMetrics = originalPromMetrics }()
+	originalPromMetrics := promMetrics.Load()
+	defer func() { promMetrics.Store(originalPromMetrics) }()
 
-	promMetrics = nil
+	promMetrics.Store(nil)
 	result := getMithrilStats()
 	if result != "" {
 		t.Errorf("getMithrilStats() with nil metrics = %q, expected empty string", result)
@@ -2010,9 +2017,9 @@ func TestIsMithrilSyncActive(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			originalPromMetrics := promMetrics
-			defer func() { promMetrics = originalPromMetrics }()
-			promMetrics = tt.metrics
+			originalPromMetrics := promMetrics.Load()
+			defer func() { promMetrics.Store(originalPromMetrics) }()
+			promMetrics.Store(tt.metrics)
 
 			got := isMithrilSyncActive()
 			if got != tt.want {
@@ -2025,13 +2032,13 @@ func TestIsMithrilSyncActive(t *testing.T) {
 // TestUpdateMithrilViewOverlayState verifies that active Mithril sync produces
 // overlay content without moving the operator away from the normal Dingo view.
 func TestUpdateMithrilViewOverlayState(t *testing.T) {
-	originalPromMetrics := promMetrics
+	originalPromMetrics := promMetrics.Load()
 	originalMithrilAutoActive := mithrilViewAutoActive.Load()
 	originalActive := getActiveSecondaryView()
 	originalDetectedBinary, _ := detectedNodeBinary.Load().(string)
 	originalOverlayText := mithrilOverlayText
 	defer func() {
-		promMetrics = originalPromMetrics
+		promMetrics.Store(originalPromMetrics)
 		mithrilViewAutoActive.Store(originalMithrilAutoActive)
 		setActiveSecondaryView(originalActive)
 		detectedNodeBinary.Store(originalDetectedBinary)
@@ -2042,10 +2049,10 @@ func TestUpdateMithrilViewOverlayState(t *testing.T) {
 	mithrilViewAutoActive.Store(false)
 	setActiveSecondaryView(viewDingo)
 
-	promMetrics = &PromMetrics{
+	promMetrics.Store(&PromMetrics{
 		MithrilSyncCompleted:    0,
 		MithrilSyncSnapshotSize: BytesInGigabyte,
-	}
+	})
 	updateMithrilView()
 	if getActiveSecondaryView() != viewDingo {
 		t.Errorf("expected viewDingo to remain active during sync, got %d", getActiveSecondaryView())
@@ -2057,7 +2064,7 @@ func TestUpdateMithrilViewOverlayState(t *testing.T) {
 		t.Fatalf("expected overlay text to contain Mithril content, got:\n%s", mithrilOverlayText)
 	}
 
-	promMetrics = &PromMetrics{MithrilSyncCompleted: 1}
+	promMetrics.Store(&PromMetrics{MithrilSyncCompleted: 1})
 	updateMithrilView()
 	if getActiveSecondaryView() != viewDingo {
 		t.Errorf("expected viewDingo after sync completion, got %d", getActiveSecondaryView())
@@ -2073,14 +2080,14 @@ func TestUpdateMithrilViewOverlayState(t *testing.T) {
 // TestGetDingoStatsShowsGovernanceFailures verifies the governance decode
 // failures counter appears in the diagnostics pane.
 func TestGetDingoStatsShowsGovernanceFailures(t *testing.T) {
-	originalPromMetrics := promMetrics
+	originalPromMetrics := promMetrics.Load()
 	originalLastDingoSample := lastDingoSample
 	originalLastDingoSampleAt := lastDingoSampleAt
 	originalLastDingoSampleSrc := lastDingoSampleSrc
 	originalLastDingoRateBase := lastDingoRateBase
 	originalLastDingoRateBaseAt := lastDingoRateBaseAt
 	defer func() {
-		promMetrics = originalPromMetrics
+		promMetrics.Store(originalPromMetrics)
 		lastDingoSample = originalLastDingoSample
 		lastDingoSampleAt = originalLastDingoSampleAt
 		lastDingoSampleSrc = originalLastDingoSampleSrc
@@ -2093,9 +2100,9 @@ func TestGetDingoStatsShowsGovernanceFailures(t *testing.T) {
 	lastDingoSample = nil
 	lastDingoSampleAt = time.Time{}
 	lastDingoSampleSrc = nil
-	promMetrics = &PromMetrics{
+	promMetrics.Store(&PromMetrics{
 		DingoGovernanceDecodeFailures: 7,
-	}
+	})
 
 	result := getDingoStats()
 	if !strings.Contains(result, "Gov Failures") {
@@ -2114,10 +2121,10 @@ func BenchmarkGetEpochProgress(b *testing.B) {
 	cfg.Node.ByronGenesis.EpochLength = 216000
 
 	// Set promMetrics
-	promMetrics = &PromMetrics{
+	promMetrics.Store(&PromMetrics{
 		EpochNum:    150,
 		SlotInEpoch: 216000,
-	}
+	})
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -2277,12 +2284,12 @@ func TestGetConnectionText(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Set globals
 			originalP2p := p2p
-			originalPromMetrics := promMetrics
+			originalPromMetrics := promMetrics.Load()
 			p2p = tt.p2p
-			promMetrics = tt.promMetrics
+			promMetrics.Store(tt.promMetrics)
 			defer func() {
 				p2p = originalP2p
-				promMetrics = originalPromMetrics
+				promMetrics.Store(originalPromMetrics)
 			}()
 
 			ctx := context.Background()
@@ -2343,17 +2350,17 @@ func TestGetCoreText(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Set globals
 			originalRole := role
-			originalPromMetrics := promMetrics
+			originalPromMetrics := promMetrics.Load()
 			cfg := config.GetConfig()
 			originalBinary := cfg.Node.Binary
 			originalDetectedBinary, _ := detectedNodeBinary.Load().(string)
 			role = tt.role
-			promMetrics = tt.promMetrics
+			promMetrics.Store(tt.promMetrics)
 			cfg.Node.Binary = ""
 			detectedNodeBinary.Store(tt.binary)
 			defer func() {
 				role = originalRole
-				promMetrics = originalPromMetrics
+				promMetrics.Store(originalPromMetrics)
 				cfg.Node.Binary = originalBinary
 				detectedNodeBinary.Store(originalDetectedBinary)
 			}()
@@ -2375,21 +2382,21 @@ func TestGetCoreTextMutesDisabledDingoForgeCounters(t *testing.T) {
 	cfg := config.GetConfig()
 	originalBinary := cfg.Node.Binary
 	originalDetectedBinary, _ := detectedNodeBinary.Load().(string)
-	originalPromMetrics := promMetrics
+	originalPromMetrics := promMetrics.Load()
 	originalRole := role
 	defer func() {
 		cfg.Node.Binary = originalBinary
 		detectedNodeBinary.Store(originalDetectedBinary)
-		promMetrics = originalPromMetrics
+		promMetrics.Store(originalPromMetrics)
 		role = originalRole
 	}()
 
 	cfg.Node.Binary = ""
 	detectedNodeBinary.Store(DINGO_BINARY)
 	role = "Relay"
-	promMetrics = &PromMetrics{
+	promMetrics.Store(&PromMetrics{
 		ForgingEnabled: 0,
-	}
+	})
 
 	result := getCoreText(context.Background())
 	for _, expected := range []string{

--- a/main_test.go
+++ b/main_test.go
@@ -638,12 +638,7 @@ func TestGetEpochProgress(t *testing.T) {
 			cfg.Node.ShelleyGenesis.EpochLength = tt.epochLength
 			cfg.Node.ByronGenesis.EpochLength = tt.epochLength
 
-			// Set global promMetrics
-			originalPromMetrics := promMetrics.Load()
-			promMetrics.Store(tt.promMetrics)
-			defer func() { promMetrics.Store(originalPromMetrics) }()
-
-			result := getEpochProgress()
+			result := getEpochProgress(tt.promMetrics)
 			if result != tt.expected {
 				t.Errorf(
 					"getEpochProgress() = %v, expected %v",
@@ -718,7 +713,6 @@ func TestFormatEpochRemaining(t *testing.T) {
 	originalByronStartTime := cfg.Node.ByronGenesis.StartTime
 	originalByronEpochLength := cfg.Node.ByronGenesis.EpochLength
 	originalByronSlotLength := cfg.Node.ByronGenesis.SlotLength
-	originalPromMetrics := promMetrics.Load()
 	defer func() {
 		cfg.Node.ShelleyTransEpoch = originalShelleyTransEpoch
 		cfg.Node.ShelleyGenesis.EpochLength = originalShelleyEpochLength
@@ -726,7 +720,6 @@ func TestFormatEpochRemaining(t *testing.T) {
 		cfg.Node.ByronGenesis.StartTime = originalByronStartTime
 		cfg.Node.ByronGenesis.EpochLength = originalByronEpochLength
 		cfg.Node.ByronGenesis.SlotLength = originalByronSlotLength
-		promMetrics.Store(originalPromMetrics)
 	}()
 
 	cfg.Node.ShelleyTransEpoch = 0
@@ -735,12 +728,12 @@ func TestFormatEpochRemaining(t *testing.T) {
 	cfg.Node.ByronGenesis.StartTime = uint64(time.Now().Unix()) - 1040
 	cfg.Node.ByronGenesis.EpochLength = 100
 	cfg.Node.ByronGenesis.SlotLength = 1000
-	promMetrics.Store(&PromMetrics{
+	metrics := &PromMetrics{
 		EpochNum:    10,
 		SlotInEpoch: 40,
-	})
+	}
 
-	remaining, ok := getEpochRemainingSeconds()
+	remaining, ok := getEpochRemainingSeconds(metrics)
 	if !ok {
 		t.Fatal("getEpochRemainingSeconds() returned !ok")
 	}
@@ -2120,15 +2113,14 @@ func BenchmarkGetEpochProgress(b *testing.B) {
 	cfg.Node.ShelleyGenesis.EpochLength = 432000
 	cfg.Node.ByronGenesis.EpochLength = 216000
 
-	// Set promMetrics
-	promMetrics.Store(&PromMetrics{
+	metrics := &PromMetrics{
 		EpochNum:    150,
 		SlotInEpoch: 216000,
-	})
+	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		getEpochProgress()
+		getEpochProgress(metrics)
 	}
 }
 
@@ -2450,5 +2442,51 @@ func TestFormatMemoryBytesUsesMegabytesBelowGigabyte(t *testing.T) {
 				t.Fatalf("formatMemoryBytes(%d) = %q, expected %q", tt.bytes, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestRenderHelpersUseArgumentSnapshotNotGlobal guards against a regression
+// where a composite renderer like getOverviewText loaded its own promMetrics
+// snapshot but then called helpers such as currentTipGap and
+// getEpochProgress that reloaded the package-level promMetrics
+// independently. If a scrape landed between those loads, one render could
+// mix fields from two different snapshots. These helpers now take the
+// caller's snapshot as a parameter and never touch the global themselves, so
+// a differing global value must not affect their output.
+func TestRenderHelpersUseArgumentSnapshotNotGlobal(t *testing.T) {
+	originalPromMetrics := promMetrics.Load()
+	defer promMetrics.Store(originalPromMetrics)
+
+	cfg := config.GetConfig()
+	originalShelleyTransEpoch := cfg.Node.ShelleyTransEpoch
+	originalShelleyEpochLength := cfg.Node.ShelleyGenesis.EpochLength
+	originalByronEpochLength := cfg.Node.ByronGenesis.EpochLength
+	defer func() {
+		cfg.Node.ShelleyTransEpoch = originalShelleyTransEpoch
+		cfg.Node.ShelleyGenesis.EpochLength = originalShelleyEpochLength
+		cfg.Node.ByronGenesis.EpochLength = originalByronEpochLength
+	}()
+	cfg.Node.ShelleyTransEpoch = 0
+	cfg.Node.ShelleyGenesis.EpochLength = 100
+	cfg.Node.ByronGenesis.EpochLength = 100
+
+	// The global holds a wildly different snapshot than the one passed
+	// explicitly below, so any accidental reload of the global is caught.
+	promMetrics.Store(&PromMetrics{SlotNum: 999999, EpochNum: 999, SlotInEpoch: 99})
+
+	argMetrics := &PromMetrics{SlotNum: 0, EpochNum: 5, SlotInEpoch: 50}
+
+	if gap, severity := currentTipGap(argMetrics); gap != 0 || severity != uiSeverityMuted {
+		t.Fatalf(
+			"currentTipGap(argMetrics) = (%d, %d), expected (0, uiSeverityMuted) from the argument's zero SlotNum, not the global's",
+			gap, severity,
+		)
+	}
+
+	if progress := getEpochProgress(argMetrics); progress != 50.0 {
+		t.Fatalf(
+			"getEpochProgress(argMetrics) = %v, expected 50 from the argument's SlotInEpoch, not the global's",
+			progress,
+		)
 	}
 }

--- a/node.go
+++ b/node.go
@@ -40,7 +40,7 @@ func setRole() {
 	r := "Relay"
 	if cfg.Node.BlockProducer {
 		r = "Core"
-	} else if promMetrics != nil && promMetrics.AboutToLead > 0 {
+	} else if m := promMetrics.Load(); m != nil && m.AboutToLead > 0 {
 		r = "Core"
 	}
 	if role != r {

--- a/peers.go
+++ b/peers.go
@@ -86,7 +86,7 @@ func filterPeers(ctx context.Context) error {
 	// Skip everything if we have no peers
 	if len(peers) == 0 {
 		resetPeers()
-		failCount.Store(0)
+		recordSubsystemSuccess(healthSubsystemPeers)
 		return nil
 	}
 
@@ -159,7 +159,7 @@ func mergePeerDirections(existing, next string) string {
 
 func pingPeers(ctx context.Context) {
 	if !dashboardShowsPeers() && getActiveSecondaryView() != viewPeers {
-		failCount.Store(0)
+		recordSubsystemSuccess(healthSubsystemPeers)
 		return
 	}
 
@@ -212,7 +212,7 @@ func pingPeers(ctx context.Context) {
 	for _, probe := range probes {
 		go probePeer(ctx, probe)
 	}
-	failCount.Store(0)
+	recordSubsystemSuccess(healthSubsystemPeers)
 }
 
 func schedulePeerProbeLocked(probe peerProbe, scheduledAt time.Time) peerProbe {

--- a/peers.go
+++ b/peers.go
@@ -86,7 +86,6 @@ func filterPeers(ctx context.Context) error {
 	// Skip everything if we have no peers
 	if len(peers) == 0 {
 		resetPeers()
-		recordSubsystemSuccess(healthSubsystemPeers)
 		return nil
 	}
 
@@ -159,7 +158,6 @@ func mergePeerDirections(existing, next string) string {
 
 func pingPeers(ctx context.Context) {
 	if !dashboardShowsPeers() && getActiveSecondaryView() != viewPeers {
-		recordSubsystemSuccess(healthSubsystemPeers)
 		return
 	}
 
@@ -212,7 +210,6 @@ func pingPeers(ctx context.Context) {
 	for _, probe := range probes {
 		go probePeer(ctx, probe)
 	}
-	recordSubsystemSuccess(healthSubsystemPeers)
 }
 
 func schedulePeerProbeLocked(probe peerProbe, scheduledAt time.Time) peerProbe {

--- a/peers_test.go
+++ b/peers_test.go
@@ -340,14 +340,10 @@ func TestPingPeersDoesNotResetPeersHealthWhenViewInactive(t *testing.T) {
 
 	// Force dashboardShowsPeers() to false and the active view to something
 	// other than viewPeers, so pingPeers takes its early-return path.
-	originalDetected := detectedNodeBinary.Load()
+	originalDetected, _ := detectedNodeBinary.Load().(string)
 	detectedNodeBinary.Store(CARDANO_BINARY)
 	defer func() {
-		if originalDetected != nil {
-			if s, ok := originalDetected.(string); ok {
-				detectedNodeBinary.Store(s)
-			}
-		}
+		detectedNodeBinary.Store(originalDetected)
 	}()
 
 	originalPeerOverlay := peerOverlayActive.Load()

--- a/peers_test.go
+++ b/peers_test.go
@@ -85,7 +85,7 @@ func TestPeerRTTResultsSortStableWhenRTTUnavailable(t *testing.T) {
 }
 
 func TestGetPeerTextRendersPartialLazyResults(t *testing.T) {
-	originalPromMetrics := promMetrics
+	originalPromMetrics := promMetrics.Load()
 	originalPeerText := peerText
 	peerStatsMu.Lock()
 	originalPeerStats := peerStats
@@ -94,7 +94,7 @@ func TestGetPeerTextRendersPartialLazyResults(t *testing.T) {
 	originalPeersFiltered := peersFiltered
 	peersFilteredMu.Unlock()
 	defer func() {
-		promMetrics = originalPromMetrics
+		promMetrics.Store(originalPromMetrics)
 		peerText = originalPeerText
 		peerStatsMu.Lock()
 		peerStats = originalPeerStats
@@ -104,13 +104,13 @@ func TestGetPeerTextRendersPartialLazyResults(t *testing.T) {
 		peersFilteredMu.Unlock()
 	}()
 
-	promMetrics = &PromMetrics{
+	promMetrics.Store(&PromMetrics{
 		PeersKnown:       2,
 		PeersEstablished: 1,
 		PeersActive:      1,
 		PeersHot:         1,
 		PeersCold:        1,
-	}
+	})
 	peersFilteredMu.Lock()
 	peersFiltered = []string{
 		"198.51.100.10;3001;o",

--- a/peers_test.go
+++ b/peers_test.go
@@ -326,3 +326,61 @@ func TestResetPeersClearsFilteredAndStats(t *testing.T) {
 		t.Fatalf("peerStats collections were not reset: %#v", peerStats)
 	}
 }
+
+// TestPingPeersDoesNotResetPeersHealthWhenViewInactive guards against a
+// regression where pingPeers reset the peers subsystem's consecutive-failure
+// count on every call, including its early return for an inactive peer
+// view. That let an unrelated, frequently-running loop mask a persistent
+// filterPeers failure: the peers subsystem would report healthy even while
+// the actual peer-filtering attempt kept failing. Only a successful
+// filterPeers(ctx) call may now clear that count.
+func TestPingPeersDoesNotResetPeersHealthWhenViewInactive(t *testing.T) {
+	original := resetSubsystemFailuresForTest()
+	defer restoreSubsystemFailuresForTest(original)
+
+	// Force dashboardShowsPeers() to false and the active view to something
+	// other than viewPeers, so pingPeers takes its early-return path.
+	originalDetected := detectedNodeBinary.Load()
+	detectedNodeBinary.Store(CARDANO_BINARY)
+	defer func() {
+		if originalDetected != nil {
+			if s, ok := originalDetected.(string); ok {
+				detectedNodeBinary.Store(s)
+			}
+		}
+	}()
+
+	originalPeerOverlay := peerOverlayActive.Load()
+	peerOverlayActive.Store(false)
+	defer peerOverlayActive.Store(originalPeerOverlay)
+
+	originalActive := activeSecondary.Load()
+	setActiveSecondaryView(viewNone)
+	defer activeSecondary.Store(originalActive)
+
+	if dashboardShowsPeers() || getActiveSecondaryView() == viewPeers {
+		t.Fatal("test setup did not produce an inactive peer view")
+	}
+
+	// Simulate a persistent filterPeers failure, the way the main peer-filter
+	// loop records it.
+	originalProcessMetrics := processMetrics
+	processMetrics = nil
+	defer func() { processMetrics = originalProcessMetrics }()
+
+	ctx := context.Background()
+	if err := filterPeers(ctx); err == nil {
+		t.Fatal("expected filterPeers to fail with processMetrics unset")
+	}
+	recordSubsystemFailure(healthSubsystemPeers)
+	recordSubsystemFailure(healthSubsystemPeers)
+
+	pingPeers(ctx)
+
+	if got := subsystemFailures[healthSubsystemPeers].Load(); got != 2 {
+		t.Fatalf(
+			"peers failure count = %d after an inactive-view pingPeers call, expected 2 to remain untouched",
+			got,
+		)
+	}
+}

--- a/prometheus.go
+++ b/prometheus.go
@@ -42,8 +42,8 @@ const epochRetryDelay = time.Second * 5
 var detectedNodeBinary atomic.Value // stores string
 
 func setCurrentEpoch() {
-	if promMetrics != nil {
-		currentEpoch = promMetrics.EpochNum
+	if m := promMetrics.Load(); m != nil {
+		currentEpoch = m.EpochNum
 	}
 }
 
@@ -76,7 +76,12 @@ func runEpochUpdateLoop(
 	}
 }
 
-var promMetrics *PromMetrics
+// promMetrics holds the current immutable metrics snapshot. It is written
+// only by the scrape goroutine (via Store, replacing the pointer with a
+// freshly parsed *PromMetrics rather than mutating fields in place) and read
+// by renderer goroutines via Load, so every reader observes a complete,
+// self-consistent snapshot instead of racing with in-progress publication.
+var promMetrics atomic.Pointer[PromMetrics]
 
 // PromMetrics holds all the Prometheus metrics collected from a Cardano node.
 // It includes metrics for blocks, epochs, slots, memory, connections, and more.
@@ -259,22 +264,22 @@ func getPromMetrics(ctx context.Context) (*PromMetrics, error) {
 	var respBodyBytes []byte
 	respBodyBytes, statusCode, err := getNodeMetrics(ctx)
 	if err != nil {
-		failCount.Add(1)
+		recordSubsystemFailure(healthSubsystemPrometheus)
 		return metrics, fmt.Errorf("failed getNodeMetrics: %w", err)
 	}
 	if statusCode != http.StatusOK {
-		failCount.Add(1)
+		recordSubsystemFailure(healthSubsystemPrometheus)
 		return metrics, fmt.Errorf("failed HTTP: %d", statusCode)
 	}
 
 	b, err := prom2json(respBodyBytes)
 	if err != nil {
-		failCount.Add(1)
+		recordSubsystemFailure(healthSubsystemPrometheus)
 		return metrics, fmt.Errorf("failed prom2json: %w", err)
 	}
 
 	if err := json.Unmarshal(b, &metrics); err != nil {
-		failCount.Add(1)
+		recordSubsystemFailure(healthSubsystemPrometheus)
 		return metrics, fmt.Errorf("failed JSON unmarshal: %w", err)
 	}
 
@@ -282,7 +287,7 @@ func getPromMetrics(ctx context.Context) (*PromMetrics, error) {
 	detectNodeType(metrics)
 
 	// panic(string(b))
-	failCount.Store(0)
+	recordSubsystemSuccess(healthSubsystemPrometheus)
 	return metrics, nil
 }
 


### PR DESCRIPTION
## Summary

- `promMetrics` is now published via `atomic.Pointer[PromMetrics]` instead of a bare package-global pointer, so the scrape goroutine's publication can no longer race with renderer goroutines reading individual fields. Every renderer loads one immutable snapshot at the top of its function.
- Replace the single shared `failCount` with per-subsystem consecutive-failure counters (Prometheus scrape, process metrics, peers), so a success in one subsystem can no longer mask an ongoing failure in another.
- Remove the duplicate failure recording that double-counted a single failed Prometheus scrape, add the missing success reset for the process-metrics subsystem, and stop unrelated renderers (terminal-size and CPU/memory read errors) from mutating connectivity health state.
- Add race-enabled concurrent scrape/render tests and independent subsystem transition tests (`health_test.go`).

Closes #498

## Changes by file

- **`health.go`** (new): per-subsystem health model — `healthSubsystem` enum (Prometheus, process, peers), `subsystemFailures` counters, `recordSubsystemFailure`/`recordSubsystemSuccess`, and `failCount()` reporting the worst subsystem's consecutive-failure streak.
- **`health_test.go`** (new): `TestSubsystemFailuresAreIndependent`, `TestFailCountReportsWorstSubsystem`, `TestGetPromMetricsAppliesResultExactlyOnce`, and the race-enabled `TestConcurrentPromMetricsPublicationAndRendering`.
- **`prometheus.go`**: `promMetrics` changed from `*PromMetrics` to `atomic.Pointer[PromMetrics]`; `setCurrentEpoch` reads via `Load()`; `getPromMetrics` now records Prometheus-subsystem health (failure on each error path, success once) instead of touching the old shared `failCount`.
- **`main.go`**: ~28 renderer/pane functions (`dashboardHealth`, `getChainText`, `getCoreText`, `getBlockText`, `getPeerText`, `getResourceText`, severity helpers, etc.) each load one immutable `promMetrics` snapshot at the top instead of reading the shared pointer field-by-field; the scrape goroutine in `main()` publishes via `Store` and no longer double-records failures; the process-metrics goroutine now records its own success; the panic-threshold check uses the new `failCount()`; unrelated `failCount` mutations tied to terminal-size/CPU/memory render errors are removed from `getCoreText`, `getBlockText`, `getPeerText`, and `getResourceText`.
- **`node.go`**: `setRole` reads `promMetrics` via `Load()`.
- **`peers.go`**: the three success-reset call sites in `filterPeers`/`pingPeers` now call `recordSubsystemSuccess(healthSubsystemPeers)` instead of the shared `failCount.Store(0)`.
- **`main_test.go`** / **`peers_test.go`**: mechanical updates for the `atomic.Pointer` type change (`promMetrics = x` → `promMetrics.Store(x)`, `:= promMetrics` → `:= promMetrics.Load()`), and `TestDashboardPaneSeverities` now saves/restores all per-subsystem counters instead of the old single `failCount`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `gofmt -s -l .` (no output)
- [x] `go test -race -count=1 ./...` (repeated runs, all pass)
- [x] Verified the new concurrency test actually catches the original bug: reintroducing the old unsynchronized `*PromMetrics` pointer in a throwaway copy makes `TestConcurrentPromMetricsPublicationAndRendering` fail under `-race`; it passes against this fix.

## Summary by cubic

Fixes a data race between the Prometheus scrape goroutine and renderer goroutines reading metric fields, and makes health tracking per-subsystem so a success in one subsystem can't mask a failure in another.

- `promMetrics` is now an `atomic.Pointer[PromMetrics]`; every renderer loads one immutable snapshot instead of reading a shared pointer's fields.
- Replaced the single `failCount` with independent consecutive-failure counters for Prometheus scrape, process metrics, and peers.
- Removed duplicate failure recording for failed scrapes and added the missing success reset for process metrics.
- Terminal-size and CPU/memory read errors no longer mutate connectivity health state.
- Added race-enabled concurrent scrape/render tests and subsystem independence tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved health monitoring by tracking failures independently across metrics, process, and peer subsystems.
  * Prevented successful activity in one subsystem from masking consecutive failures in another.
  * Improved concurrent access to Prometheus metrics, reducing the risk of inconsistent reads and nil-pointer errors.
  * Corrected failure counting to avoid duplicate reporting for a single failed metrics scrape.

* **Tests**
  * Added coverage for subsystem failure tracking, aggregate health severity, concurrent metrics access, and Prometheus failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->